### PR TITLE
fix(message): limit hours and minutes offsets in parseOffset function

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,4 +23,5 @@ IRC_COMMAND_PREFIX=!
 IRC_OWNERS=obviyus
 
 # Database Configuration
-DATABASE_PATH=./HamVerBot.db
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 ## ✨ Features
 
 ### Commands
+
 - `!next [timezone]` - Time until the next event (supports timezone like `utc+1`, `gmt-5:30`)
 - `!when [event] [timezone]` - Time until a specific event (fp1, fp2, fp3, qualifying, sprint, race)
 - `!prev` - Get results from the last completed event
@@ -24,6 +25,7 @@
 - `!help` - List all available commands
 
 ### Automated Updates 🤖
+
 - 🏁 Automatic event alerts 5 minutes before start
 - 📊 Real-time race results posted to configured channels
 - 🔄 Hourly updates of WDC and WCC standings
@@ -58,8 +60,9 @@ IRC_COMMAND_PREFIX=!
 # Admin Settings
 IRC_OWNERS=obviyus
 
-# Database Configuration
-DATABASE_PATH=./HamVerBot.db
+# Database Configuration, see: https://turso.tech/
+TURSO_DATABASE_URL=
+TURSO_AUTH_TOKEN=
 ```
 
 To run the bot:

--- a/src/message.ts
+++ b/src/message.ts
@@ -54,19 +54,42 @@ function parseOffset(offsetStr: string): number | undefined {
 	if (parts.length === 1) {
 		// Just hours
 		const hours = Number.parseInt(parts[0], 10);
-		if (Number.isNaN(hours)) return undefined;
+		if (Number.isNaN(hours) || !isValidHoursOffset(hours * sign)) return undefined;
 		seconds = hours * 3600;
 	} else if (parts.length === 2) {
 		// Hours and minutes
 		const hours = Number.parseInt(parts[0], 10);
 		const minutes = Number.parseInt(parts[1], 10);
-		if (Number.isNaN(hours) || Number.isNaN(minutes)) return undefined;
+		if (Number.isNaN(hours) || !isValidHoursOffset(hours * sign)) return undefined;
+		if (Number.isNaN(minutes) || !isValidMinutesOffset(minutes)) return undefined;
 		seconds = hours * 3600 + minutes * 60;
 	} else {
 		return undefined;
 	}
 
 	return (seconds * sign) / 60;
+}
+
+/**
+ * Check if the hours offset is within valid range (from -12 to +14)
+ * @param signedOffset - A signed hours offset
+ * @returns True if the offset is within the range
+ */
+function isValidHoursOffset(signedOffset: number): boolean {
+	const minHoursOffset = -12, maxHoursOffset = 14;
+
+	return signedOffset >= minHoursOffset && signedOffset <= maxHoursOffset;
+}
+
+/**
+ * Check if the minutes offset is within valid range (from 0 to 59)
+ * @param minutes - A minutes offset
+ * @returns True if minutes are within the range
+ */
+function isValidMinutesOffset(minutes: number): boolean {
+	const minMinutesOffset = 0, maxMinutesOffset = 59;
+
+	return minutes >= minMinutesOffset && minutes <= maxMinutesOffset;
 }
 
 /**


### PR DESCRIPTION
As we've discussed [here](https://github.com/obviyus/HamVerBot/issues/68), I added a check for hours and minutes offsets.

* Hours: from -12 to +14 per [the list of UTC offsets](https://en.wikipedia.org/wiki/List_of_UTC_offsets).
* Minutes: from 0 to 59 per common sense.

I also understand that you no longer use a local sqlite database in this project, but `.env.example` and `README.md` didn't reflect that. I updated them.

![image](https://github.com/user-attachments/assets/0ed6bdcf-66cd-47d9-9cde-3a315cd126b0)
