### PR TITLE
Centralize event helpers

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,12 +1,13 @@
 import {
-	getDb,
-	storeDriver,
-	storeEventResult,
-	storeChampionshipStandings,
-	getNextEvent,
-	EventType,
-	getEventTypeName,
+        getDb,
+        storeDriver,
+        storeEventResult,
+        storeChampionshipStandings,
+        getNextEvent,
+        EventType,
+        getEventTypeName,
 } from "~/database";
+import { eventTypeToString, sessionKeyToEventType } from "~/utils/events";
 import type {
 	Driver,
 	DriverStanding,
@@ -544,76 +545,3 @@ export async function fetchNextEvent(): Promise<string | null> {
 	}
 }
 
-/**
- * Convert EventType enum to string
- */
-function eventTypeToString(eventType: EventType): string {
-	switch (eventType) {
-		case EventType.LiveryReveal:
-			return "Livery Reveal";
-		case EventType.FreePractice1:
-			return "Free Practice 1";
-		case EventType.FreePractice2:
-			return "Free Practice 2";
-		case EventType.FreePractice3:
-			return "Free Practice 3";
-		case EventType.Qualifying:
-			return "Qualifying";
-		case EventType.Sprint:
-			return "Sprint Race";
-		case EventType.Race:
-			return "Race";
-		case EventType.SprintQualifying:
-			return "Sprint Qualifying";
-		default:
-			return "Unknown Event";
-	}
-}
-
-/**
- * Convert session key to EventType
- */
-function sessionKeyToEventType(key: string): EventType | null {
-	switch (key) {
-		case "fp1":
-			return EventType.FreePractice1;
-		case "fp2":
-			return EventType.FreePractice2;
-		case "fp3":
-			return EventType.FreePractice3;
-		case "qualifying":
-			return EventType.Qualifying;
-		case "sprint":
-			return EventType.Sprint;
-		case "race":
-			return EventType.Race;
-		case "sprintQualifying":
-			return EventType.SprintQualifying;
-		default:
-			return null;
-	}
-}
-
-/**
- * Convert EventType to emoji
- */
-export function eventTypeToEmoji(eventType: EventType): string {
-	switch (eventType) {
-		case EventType.LiveryReveal:
-			return "🎨";
-		case EventType.FreePractice1:
-		case EventType.FreePractice2:
-		case EventType.FreePractice3:
-			return "🏎️";
-		case EventType.Qualifying:
-			return "⏱️";
-		case EventType.Sprint:
-			return "🏁";
-		case EventType.Race:
-			return "🏎️";
-		case EventType.SprintQualifying:
-			return "⏱️";
-		default:
-			return "🏎️";
-	}
-}

--- a/src/message.ts
+++ b/src/message.ts
@@ -1,10 +1,14 @@
 import { EventType, getLatestPath, getNextEvent } from "./database";
 import {
-	fetchResults,
-	returnWdcStandings,
-	returnWccStandings,
-	eventTypeToEmoji,
+        fetchResults,
+        returnWdcStandings,
+        returnWccStandings,
 } from "./fetch";
+import {
+        eventTypeToEmoji,
+        eventTypeToString,
+        stringToEventType,
+} from "~/utils/events";
 import { getClient } from "./irc";
 
 /**
@@ -92,102 +96,6 @@ function isValidMinutesOffset(minutes: number): boolean {
 	return minutes >= minMinutesOffset && minutes <= maxMinutesOffset;
 }
 
-/**
- * Convert an event type to its string representation
- * @param eventType - The event type
- * @returns The string representation of the event type
- */
-function eventTypeToString(eventType: EventType): string {
-	switch (eventType) {
-		case EventType.LiveryReveal:
-			return "Livery Reveal";
-		case EventType.FreePractice1:
-			return "Free Practice 1";
-		case EventType.FreePractice2:
-			return "Free Practice 2";
-		case EventType.FreePractice3:
-			return "Free Practice 3";
-		case EventType.Qualifying:
-			return "Qualifying";
-		case EventType.Sprint:
-			return "Sprint";
-		case EventType.Race:
-			return "Race";
-		case EventType.SprintQualifying:
-			return "Sprint Qualifying";
-		default:
-			return "Unknown";
-	}
-}
-
-/**
- * Convert a string to an event type
- * @param str - The string to convert
- * @returns The corresponding event type or undefined if not found
- */
-function stringToEventType(str?: string): EventType | undefined {
-	if (!str) return undefined;
-
-	const lowerStr = str.toLowerCase();
-
-	if (
-		lowerStr.includes("fp1") ||
-		lowerStr.includes("practice1") ||
-		lowerStr.includes("p1")
-	) {
-		return EventType.FreePractice1;
-	}
-
-	if (
-		lowerStr.includes("fp2") ||
-		lowerStr.includes("practice2") ||
-		lowerStr.includes("p2")
-	) {
-		return EventType.FreePractice2;
-	}
-
-	if (
-		lowerStr.includes("fp3") ||
-		lowerStr.includes("practice3") ||
-		lowerStr.includes("p3")
-	) {
-		return EventType.FreePractice3;
-	}
-
-	if (lowerStr.includes("sq")) {
-		return EventType.SprintQualifying;
-	}
-
-	if (
-		lowerStr.includes("quali") ||
-		lowerStr.includes("q") ||
-		lowerStr.includes("qualifying")
-	) {
-		return EventType.Qualifying;
-	}
-
-	if (
-		lowerStr.includes("sprint") ||
-		lowerStr.includes("s") ||
-		lowerStr.includes("sprint race")
-	) {
-		return EventType.Sprint;
-	}
-
-	if (
-		lowerStr.includes("race") ||
-		lowerStr.includes("r") ||
-		lowerStr.includes("gp")
-	) {
-		return EventType.Race;
-	}
-
-	if (lowerStr.includes("livery") || lowerStr.includes("l")) {
-		return EventType.LiveryReveal;
-	}
-
-	return undefined;
-}
 
 /**
  * Build a time string for an event

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,0 +1,78 @@
+import { EventType } from "~/database";
+
+const typeNames: Record<EventType, string> = {
+  [EventType.LiveryReveal]: "Livery Reveal",
+  [EventType.FreePractice1]: "Free Practice 1",
+  [EventType.FreePractice2]: "Free Practice 2",
+  [EventType.FreePractice3]: "Free Practice 3",
+  [EventType.Qualifying]: "Qualifying",
+  [EventType.Sprint]: "Sprint",
+  [EventType.Race]: "Race",
+  [EventType.SprintQualifying]: "Sprint Qualifying",
+};
+
+const typeEmojis: Record<EventType, string> = {
+  [EventType.LiveryReveal]: "🎨",
+  [EventType.FreePractice1]: "🏎️",
+  [EventType.FreePractice2]: "🏎️",
+  [EventType.FreePractice3]: "🏎️",
+  [EventType.Qualifying]: "⏱️",
+  [EventType.Sprint]: "🏁",
+  [EventType.Race]: "🏎️",
+  [EventType.SprintQualifying]: "⏱️",
+};
+
+const stringMap: Record<string, EventType> = {
+  fp1: EventType.FreePractice1,
+  practice1: EventType.FreePractice1,
+  p1: EventType.FreePractice1,
+  fp2: EventType.FreePractice2,
+  practice2: EventType.FreePractice2,
+  p2: EventType.FreePractice2,
+  fp3: EventType.FreePractice3,
+  practice3: EventType.FreePractice3,
+  p3: EventType.FreePractice3,
+  sq: EventType.SprintQualifying,
+  quali: EventType.Qualifying,
+  qualifying: EventType.Qualifying,
+  q: EventType.Qualifying,
+  sprint: EventType.Sprint,
+  "sprint race": EventType.Sprint,
+  s: EventType.Sprint,
+  race: EventType.Race,
+  r: EventType.Race,
+  gp: EventType.Race,
+  livery: EventType.LiveryReveal,
+  l: EventType.LiveryReveal,
+};
+
+const sessionKeyMap: Record<string, EventType> = {
+  fp1: EventType.FreePractice1,
+  fp2: EventType.FreePractice2,
+  fp3: EventType.FreePractice3,
+  qualifying: EventType.Qualifying,
+  sprint: EventType.Sprint,
+  race: EventType.Race,
+  sprintQualifying: EventType.SprintQualifying,
+};
+
+export function eventTypeToString(eventType: EventType): string {
+  return typeNames[eventType] ?? "Unknown";
+}
+
+export function eventTypeToEmoji(eventType: EventType): string {
+  return typeEmojis[eventType] ?? "🏎️";
+}
+
+export function stringToEventType(str?: string): EventType | undefined {
+  if (!str) return undefined;
+  const lower = str.toLowerCase();
+  for (const [key, value] of Object.entries(stringMap)) {
+    if (lower.includes(key)) return value;
+  }
+  return undefined;
+}
+
+export function sessionKeyToEventType(key: string): EventType | null {
+  return sessionKeyMap[key] ?? null;
+}


### PR DESCRIPTION
## Summary
- move event helper functions into `src/utils/events.ts`
- reuse helpers in the bot logic

## Testing
- `bun x tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_684006cce4488325a0e8077a044efe5c