### PR TITLE
refactor: simplify bot code paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,75 +7,65 @@
 
 ## [1.5.6](https://github.com/obviyus/HamVerBot/compare/v1.5.5...v1.5.6) (2026-03-29)
 
-
 ### Bug Fixes
 
-* sync cancelled calendar events ([b63f0fb](https://github.com/obviyus/HamVerBot/commit/b63f0fbe24d9cb88a9622297409b1495ddc5a397))
+- sync cancelled calendar events ([b63f0fb](https://github.com/obviyus/HamVerBot/commit/b63f0fbe24d9cb88a9622297409b1495ddc5a397))
 
 ## [1.5.5](https://github.com/obviyus/HamVerBot/compare/v1.5.4...v1.5.5) (2026-03-17)
 
-
 ### Performance Improvements
 
-* **db:** reduce turso round-trips ([69c119c](https://github.com/obviyus/HamVerBot/commit/69c119c223e5aab1a1c156f475c19b8d73954c59))
+- **db:** reduce turso round-trips ([69c119c](https://github.com/obviyus/HamVerBot/commit/69c119c223e5aab1a1c156f475c19b8d73954c59))
 
 ## [1.5.4](https://github.com/obviyus/HamVerBot/compare/v1.5.3...v1.5.4) (2026-03-08)
 
-
 ### Bug Fixes
 
-* **live-timing:** restore live pitstops ([20a280b](https://github.com/obviyus/HamVerBot/commit/20a280b5eeb02de3eefffdea2ff6d9fda9cce4fb))
+- **live-timing:** restore live pitstops ([20a280b](https://github.com/obviyus/HamVerBot/commit/20a280b5eeb02de3eefffdea2ff6d9fda9cce4fb))
 
 ## [1.5.3](https://github.com/obviyus/HamVerBot/compare/v1.5.2...v1.5.3) (2026-03-07)
 
-
 ### Bug Fixes
 
-* **live-timing:** unify current session transport ([15aeeb6](https://github.com/obviyus/HamVerBot/commit/15aeeb6f3e2de1981c15daefb22c033a94dd8f22))
+- **live-timing:** unify current session transport ([15aeeb6](https://github.com/obviyus/HamVerBot/commit/15aeeb6f3e2de1981c15daefb22c033a94dd8f22))
 
 ## [1.5.2](https://github.com/obviyus/HamVerBot/compare/v1.5.1...v1.5.2) (2026-03-07)
 
-
 ### Bug Fixes
 
-* **live-timing:** add bun-safe signalr http client ([f41cd03](https://github.com/obviyus/HamVerBot/commit/f41cd03973d36406f76a0cc25b6869590aaee41d))
+- **live-timing:** add bun-safe signalr http client ([f41cd03](https://github.com/obviyus/HamVerBot/commit/f41cd03973d36406f76a0cc25b6869590aaee41d))
 
 ## [1.5.1](https://github.com/obviyus/HamVerBot/compare/v1.5.0...v1.5.1) (2026-03-07)
 
-
 ### Bug Fixes
 
-* **live-timing:** use signalr for live race control ([7b3fdd1](https://github.com/obviyus/HamVerBot/commit/7b3fdd19ed6cb607e61ebec5161e343349304e31))
+- **live-timing:** use signalr for live race control ([7b3fdd1](https://github.com/obviyus/HamVerBot/commit/7b3fdd19ed6cb607e61ebec5161e343349304e31))
 
 # [1.5.0](https://github.com/obviyus/HamVerBot/compare/v1.4.8...v1.5.0) (2026-03-07)
 
-
 ### Bug Fixes
 
-* **events:** prioritize sprint qualifying aliases ([f43b608](https://github.com/obviyus/HamVerBot/commit/f43b608decd0515101c16ff752e07db491d93472))
-* **standings:** handle empty current-season results ([fe8b751](https://github.com/obviyus/HamVerBot/commit/fe8b751b5f7da0f4ff87e35bd91e5204523530e2))
-
+- **events:** prioritize sprint qualifying aliases ([f43b608](https://github.com/obviyus/HamVerBot/commit/f43b608decd0515101c16ff752e07db491d93472))
+- **standings:** handle empty current-season results ([fe8b751](https://github.com/obviyus/HamVerBot/commit/fe8b751b5f7da0f4ff87e35bd91e5204523530e2))
 
 ### Features
 
-* **autopost:** add channel race control alerts ([6f9a939](https://github.com/obviyus/HamVerBot/commit/6f9a939f6c803659209c6b19ff83399f9bf4475f))
-* **commands:** add driver head-to-head command ([6379506](https://github.com/obviyus/HamVerBot/commit/63795062559d6782f549d7324be959e3654c268d))
-* **commands:** add live timing commands and safe replies ([92db369](https://github.com/obviyus/HamVerBot/commit/92db369589ab9d35df846b00a557745da450b654))
+- **autopost:** add channel race control alerts ([6f9a939](https://github.com/obviyus/HamVerBot/commit/6f9a939f6c803659209c6b19ff83399f9bf4475f))
+- **commands:** add driver head-to-head command ([6379506](https://github.com/obviyus/HamVerBot/commit/63795062559d6782f549d7324be959e3654c268d))
+- **commands:** add live timing commands and safe replies ([92db369](https://github.com/obviyus/HamVerBot/commit/92db369589ab9d35df846b00a557745da450b654))
 
 ## [1.4.8](https://github.com/obviyus/HamVerBot/compare/v1.4.7...v1.4.8) (2026-02-15)
 
-
 ### Bug Fixes
 
-* **calendar:** guard parsed ics event fields ([306c2bb](https://github.com/obviyus/HamVerBot/commit/306c2bbc683d41193deef13edb9d1af3b12f8826))
-* **lint:** resolve type-aware async warnings ([82550b4](https://github.com/obviyus/HamVerBot/commit/82550b46394b2567d9fce070ecf1ce74abc65682))
+- **calendar:** guard parsed ics event fields ([306c2bb](https://github.com/obviyus/HamVerBot/commit/306c2bbc683d41193deef13edb9d1af3b12f8826))
+- **lint:** resolve type-aware async warnings ([82550b4](https://github.com/obviyus/HamVerBot/commit/82550b46394b2567d9fce070ecf1ce74abc65682))
 
 ## [1.4.7](https://github.com/obviyus/HamVerBot/compare/v1.4.6...v1.4.7) (2026-02-15)
 
-
 ### Bug Fixes
 
-* **irc:** force ipv4 for bun tls libera ([004b433](https://github.com/obviyus/HamVerBot/commit/004b4334aa9520970efc67c72087fc7ec9db73c2))
+- **irc:** force ipv4 for bun tls libera ([004b433](https://github.com/obviyus/HamVerBot/commit/004b4334aa9520970efc67c72087fc7ec9db73c2))
 
 ## [1.4.6](https://github.com/obviyus/HamVerBot/compare/v1.4.5...v1.4.6) (2026-01-08)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,8 @@
 ## [1.5.7](https://github.com/obviyus/HamVerBot/compare/v1.5.6...v1.5.7) (2026-04-07)
 
-
 ### Bug Fixes
 
-* wait for irc registration before rejoining ([03317dc](https://github.com/obviyus/HamVerBot/commit/03317dcb89011a2855186d9e85f0d4358637be94))
+- wait for irc registration before rejoining ([03317dc](https://github.com/obviyus/HamVerBot/commit/03317dcb89011a2855186d9e85f0d4358637be94))
 
 ## [1.5.6](https://github.com/obviyus/HamVerBot/compare/v1.5.5...v1.5.6) (2026-03-29)
 

--- a/scripts/sync-turso-schema.ts
+++ b/scripts/sync-turso-schema.ts
@@ -3,6 +3,11 @@ import { dirname, resolve } from "node:path";
 import { createClient } from "@libsql/client";
 
 const DEFAULT_OUTPUT_PATH = "db/schema.sql";
+const IF_NOT_EXISTS_REPLACEMENTS = [
+	["CREATE TABLE IF NOT EXISTS ", "CREATE TABLE "],
+	["CREATE UNIQUE INDEX IF NOT EXISTS ", "CREATE UNIQUE INDEX "],
+	["CREATE INDEX IF NOT EXISTS ", "CREATE INDEX "],
+] as const;
 
 const targetPath = resolve(Bun.argv[2] ?? DEFAULT_OUTPUT_PATH);
 const databaseUrl = Bun.env.TURSO_DATABASE_URL;
@@ -34,51 +39,28 @@ const result = await db.execute(`
 		name
 `);
 
-function getSqlStatement(row: Record<string, unknown>): string {
-	if (typeof row.sql !== "string") {
-		throw new Error("Invalid sqlite_master row: expected sql to be a string");
-	}
-
-	return row.sql;
-}
-
-function normalizeStatement(sql: string): string {
-	let normalized = sql
-		.trim()
-		.replace(/\r\n/g, "\n")
-		.replace(/\n[ \t]+/g, "\n  ");
-
-	if (
-		normalized.startsWith("CREATE TABLE ") &&
-		!normalized.startsWith("CREATE TABLE IF NOT EXISTS ")
-	) {
-		normalized = normalized.replace("CREATE TABLE ", "CREATE TABLE IF NOT EXISTS ");
-	}
-
-	if (
-		normalized.startsWith("CREATE UNIQUE INDEX ") &&
-		!normalized.startsWith("CREATE UNIQUE INDEX IF NOT EXISTS ")
-	) {
-		normalized = normalized.replace("CREATE UNIQUE INDEX ", "CREATE UNIQUE INDEX IF NOT EXISTS ");
-	}
-
-	if (
-		normalized.startsWith("CREATE INDEX ") &&
-		!normalized.startsWith("CREATE INDEX IF NOT EXISTS ")
-	) {
-		normalized = normalized.replace("CREATE INDEX ", "CREATE INDEX IF NOT EXISTS ");
-	}
-
-	return normalized
-		.split("\n")
-		.map((line) => line.replace(/[ \t]+$/g, ""))
-		.join("\n");
-}
-
 const statements = result.rows
-	.map(getSqlStatement)
-	.map(normalizeStatement)
-	.map((sql) => `${sql};`);
+	.map((row) => {
+		if (typeof row.sql !== "string") {
+			throw new Error("Invalid sqlite_master row: expected sql to be a string");
+		}
+
+		return row.sql;
+	})
+	.map((sql) => {
+		let normalized = sql.trim().replace(/\r\n/g, "\n").replace(/\n[ \t]+/g, "\n  ");
+		for (const [expanded, compact] of IF_NOT_EXISTS_REPLACEMENTS) {
+			if (normalized.startsWith(compact) && !normalized.startsWith(expanded)) {
+				normalized = normalized.replace(compact, expanded);
+				break;
+			}
+		}
+
+		return `${normalized
+			.split("\n")
+			.map((line) => line.replace(/[ \t]+$/g, ""))
+			.join("\n")};`;
+	});
 
 if (statements.length === 0) {
 	throw new Error("No schema statements found in sqlite_master");

--- a/scripts/sync-turso-schema.ts
+++ b/scripts/sync-turso-schema.ts
@@ -48,7 +48,10 @@ const statements = result.rows
 		return row.sql;
 	})
 	.map((sql) => {
-		let normalized = sql.trim().replace(/\r\n/g, "\n").replace(/\n[ \t]+/g, "\n  ");
+		let normalized = sql
+			.trim()
+			.replace(/\r\n/g, "\n")
+			.replace(/\n[ \t]+/g, "\n  ");
 		for (const [expanded, compact] of IF_NOT_EXISTS_REPLACEMENTS) {
 			if (normalized.startsWith(compact) && !normalized.startsWith(expanded)) {
 				normalized = normalized.replace(compact, expanded);

--- a/src/app.ts
+++ b/src/app.ts
@@ -8,10 +8,13 @@ import { scheduleJobs } from "~/worker";
 type ExitFn = typeof process.exit;
 type OnFn = typeof process.on;
 
-export async function start(): Promise<void> {
-	const nickname = appConfig.irc.nickname;
+const defaultExit: ExitFn = (code) => process.exit(code);
+const defaultOn: OnFn = (...args) => process.on(...args);
 
-	if (appConfig.irc.nickPassword === "password") {
+export async function start(): Promise<void> {
+	const { irc } = appConfig;
+
+	if (irc.nickPassword === "password") {
 		console.warn(
 			"WARNING: Using default NickServ password. Set IRC_NICK_PASSWORD in your .env file.",
 		);
@@ -31,39 +34,38 @@ export async function start(): Promise<void> {
 	scheduleJobs();
 	console.log("Scheduled all cron jobs");
 
-	console.log(`Bot nickname: ${appConfig.irc.nickname}`);
-	console.log(`Connecting to ${appConfig.irc.server}:${appConfig.irc.port}`);
+	console.log(`Bot nickname: ${irc.nickname}`);
+	console.log(`Connecting to ${irc.server}:${irc.port}`);
 
 	await initIrcClient({
-		server: appConfig.irc.server,
-		port: appConfig.irc.port,
-		nickname: appConfig.irc.nickname,
-		username: appConfig.irc.nickname,
-		realname: appConfig.irc.realname,
-		password: appConfig.irc.password,
-		nickPassword: appConfig.irc.nickPassword,
-		secure: appConfig.irc.useTls,
-		channels: appConfig.irc.channels,
+		server: irc.server,
+		port: irc.port,
+		nickname: irc.nickname,
+		username: irc.nickname,
+		realname: irc.realname,
+		password: irc.password,
+		nickPassword: irc.nickPassword,
+		secure: irc.useTls,
+		channels: irc.channels,
 	});
 
-	console.log(`${nickname} started successfully...`);
+	console.log(`${irc.nickname} started successfully...`);
 }
 
 export function registerSignalHandlers(
-	on: OnFn = process.on.bind(process),
-	exit: ExitFn = process.exit,
+	on: OnFn = defaultOn,
+	exit: ExitFn = defaultExit,
 ): void {
 	on("SIGINT", () => {
 		console.log("Received SIGINT. Shutting down...");
-		const client = getClient();
-		client.quit("Grazzi ragazzi!");
+		getClient().quit("Grazzi ragazzi!");
 		exit(0);
 	});
 }
 
 export async function main(
-	exit: ExitFn = process.exit,
-	on: OnFn = process.on.bind(process),
+	exit: ExitFn = defaultExit,
+	on: OnFn = defaultOn,
 ): Promise<void> {
 	try {
 		await start();

--- a/src/app.ts
+++ b/src/app.ts
@@ -52,10 +52,7 @@ export async function start(): Promise<void> {
 	console.log(`${irc.nickname} started successfully...`);
 }
 
-export function registerSignalHandlers(
-	on: OnFn = defaultOn,
-	exit: ExitFn = defaultExit,
-): void {
+export function registerSignalHandlers(on: OnFn = defaultOn, exit: ExitFn = defaultExit): void {
 	on("SIGINT", () => {
 		console.log("Received SIGINT. Shutting down...");
 		getClient().quit("Grazzi ragazzi!");
@@ -63,10 +60,7 @@ export function registerSignalHandlers(
 	});
 }
 
-export async function main(
-	exit: ExitFn = defaultExit,
-	on: OnFn = defaultOn,
-): Promise<void> {
+export async function main(exit: ExitFn = defaultExit, on: OnFn = defaultOn): Promise<void> {
 	try {
 		await start();
 		registerSignalHandlers(on, exit);

--- a/src/calendar.ts
+++ b/src/calendar.ts
@@ -3,163 +3,115 @@ import type { Event } from "~/database";
 import { storeEvents } from "~/database";
 import { EventType } from "~/types/event-type";
 
-// Helper function to determine event type from summary
-// Simplified determineEventType
-function determineEventType(summary: string): EventType | null {
-	const lowerSummary = summary.toLowerCase();
+const ICS_URL = "https://ics.ecal.com/ecal-sub/660897ca63f9ca0008bcbea6/Formula%201.ics";
 
-	// Order patterns from most specific to least specific
-	const eventTypePatterns: [string, EventType][] = [
-		["sprint qualifying", EventType.SprintQualifying], // Full name
-		["sprint quali", EventType.SprintQualifying], // Truncated version from ICS
-		["sprint race", EventType.Sprint], // Distinguish from Sprint Qualifying
-		["qualifying", EventType.Qualifying],
-		["practice 1", EventType.FreePractice1],
-		["fp1", EventType.FreePractice1],
-		["practice 2", EventType.FreePractice2],
-		["fp2", EventType.FreePractice2],
-		["practice 3", EventType.FreePractice3],
-		["fp3", EventType.FreePractice3],
-		["sprint", EventType.Sprint], // Check 'sprint' after more specific patterns
-		["race", EventType.Race],
-		["livery", EventType.LiveryReveal],
-	];
+const EVENT_TYPE_PATTERNS: Array<[string, EventType]> = [
+	["sprint qualifying", EventType.SprintQualifying],
+	["sprint quali", EventType.SprintQualifying],
+	["sprint race", EventType.Sprint],
+	["qualifying", EventType.Qualifying],
+	["practice 1", EventType.FreePractice1],
+	["fp1", EventType.FreePractice1],
+	["practice 2", EventType.FreePractice2],
+	["fp2", EventType.FreePractice2],
+	["practice 3", EventType.FreePractice3],
+	["fp3", EventType.FreePractice3],
+	["sprint", EventType.Sprint],
+	["race", EventType.Race],
+	["livery", EventType.LiveryReveal],
+];
 
-	for (const [pattern, eventType] of eventTypePatterns) {
-		if (lowerSummary.includes(pattern)) {
-			return eventType;
-		}
-	}
+const MEETING_NAME_INDICATORS = [
+	" Race",
+	" Sprint",
+	" Qualifying",
+	" FP1",
+	" FP2",
+	" FP3",
+	" Practice 1",
+	" Practice 2",
+	" Practice 3",
+	" Livery",
+];
 
-	return null;
-}
+const EVENT_TYPE_SUFFIXES: Record<EventType, string> = {
+	[EventType.FreePractice1]: "fp1",
+	[EventType.FreePractice2]: "fp2",
+	[EventType.FreePractice3]: "fp3",
+	[EventType.Qualifying]: "qualifying",
+	[EventType.Sprint]: "sprint",
+	[EventType.SprintQualifying]: "sprint-qualifying",
+	[EventType.Race]: "race",
+	[EventType.LiveryReveal]: "livery",
+};
 
-// Extract the meeting name from the summary
-function extractMeetingName(summary: string): string {
-	// Example: "🏁 FORMULA 1 PIRELLI GRAND PRIX DU CANADA 2025 - Race"
-	// We want to extract "FORMULA 1 PIRELLI GRAND PRIX DU CANADA 2025"
-
-	// Remove emoji and other non-alphanumeric prefixes
-	const cleanSummary = summary.replace(/^[^\w\s]+/, "").trim();
-
-	// Better handling of different summary formats
-	const dashIndex = cleanSummary.lastIndexOf(" - ");
-	if (dashIndex > 0) {
-		return cleanSummary.substring(0, dashIndex).trim();
-	}
-
-	// If there's no dash, try to extract based on event type indicators
-	const eventTypeIndicators = [
-		" Race",
-		" Sprint",
-		" Qualifying",
-		" FP1",
-		" FP2",
-		" FP3",
-		" Practice 1",
-		" Practice 2",
-		" Practice 3",
-		" Livery",
-	];
-
-	for (const indicator of eventTypeIndicators) {
-		const index = cleanSummary.indexOf(indicator);
-		if (index > 0) {
-			return cleanSummary.substring(0, index).trim();
-		}
-	}
-
-	// If no specific format is found, return the cleaned summary
-	return cleanSummary;
-}
-
-function createEventSlug(meetingName: string, eventType: EventType, startTime: number): string {
-	const date = new Date(startTime * 1000);
-	const year = date.getFullYear();
-
-	// Extract the shortened Grand Prix name
-	const gpName = meetingName
-		.toLowerCase()
-		.replace(/formula\s*1\s*/i, "")
-		.replace(/\d{4}/g, "")
-		.replace(/grand prix/gi, "gp")
-		.trim()
-		.replace(/\s+/g, "-")
-		.replace(/-+/g, "-")
-		.replace(/^-|-$/g, "");
-
-	// Map event types to slug suffixes
-	const eventTypeSuffixes: Record<EventType, string> = {
-		[EventType.FreePractice1]: "fp1",
-		[EventType.FreePractice2]: "fp2",
-		[EventType.FreePractice3]: "fp3",
-		[EventType.Qualifying]: "qualifying",
-		[EventType.Sprint]: "sprint",
-		[EventType.SprintQualifying]: "sprint-qualifying",
-		[EventType.Race]: "race",
-		[EventType.LiveryReveal]: "livery",
-	};
-
-	const suffix = eventTypeSuffixes[eventType];
-	return `${year}-${gpName}-${suffix}`;
-}
-
-// Fetch and parse the F1 calendar ICS file
 export async function fetchF1Calendar(): Promise<void> {
 	console.log("Fetching F1 calendar...");
 
-	const icsUrl = "https://ics.ecal.com/ecal-sub/660897ca63f9ca0008bcbea6/Formula%201.ics";
-
-	try {
-		// Using Bun's fetch API
-		const response = await fetch(icsUrl);
-		if (!response.ok) {
-			throw new Error(`Failed to fetch ICS file: ${response.status} ${response.statusText}`);
-		}
-
-		const icsData = await response.text();
-		const parsedData = ical.parseICS(icsData);
-
-		const events: Event[] = [];
-
-		// Process events more efficiently
-		for (const key in parsedData) {
-			const event = parsedData[key];
-			if (!event || event.type !== "VEVENT") continue;
-
-			if (typeof event.summary !== "string") continue;
-			if (!(event.start instanceof Date)) continue;
-
-			const summary = event.summary;
-			const eventType = determineEventType(summary);
-
-			// Skip events we don't care about
-			if (!eventType) {
-				console.log(`Skipping event with unknown type: ${summary}`);
-				continue;
-			}
-
-			const startDate = event.start;
-			const meetingName = extractMeetingName(summary);
-			const startTime = Math.floor(startDate.getTime() / 1000);
-
-			events.push({
-				meetingName,
-				eventTypeId: eventType,
-				startTime,
-				eventSlug: createEventSlug(meetingName, eventType, startTime),
-			});
-		}
-
-		// Store all events at once
-		if (events.length > 0) {
-			await storeEvents(events);
-			console.log(`Successfully processed ${events.length} F1 events`);
-		} else {
-			console.warn("No F1 events found in the calendar");
-		}
-	} catch (error) {
-		console.error("Error fetching or parsing F1 calendar:", error);
-		throw error;
+	const response = await fetch(ICS_URL);
+	if (!response.ok) {
+		throw new Error(`Failed to fetch ICS file: ${response.status} ${response.statusText}`);
 	}
+
+	const parsedData = ical.parseICS(await response.text());
+	const events: Event[] = [];
+
+	for (const calendarEvent of Object.values(parsedData)) {
+		if (
+			!calendarEvent ||
+			calendarEvent.type !== "VEVENT" ||
+			typeof calendarEvent.summary !== "string" ||
+			!(calendarEvent.start instanceof Date)
+		) {
+			continue;
+		}
+
+		const lowerSummary = calendarEvent.summary.toLowerCase();
+		const eventType = EVENT_TYPE_PATTERNS.find(([pattern]) => lowerSummary.includes(pattern))?.[1];
+		if (!eventType) {
+			console.log(`Skipping event with unknown type: ${calendarEvent.summary}`);
+			continue;
+		}
+
+		const cleanSummary = calendarEvent.summary.replace(/^[^\w\s]+/, "").trim();
+		let meetingName = cleanSummary;
+		const [dashedMeetingName] = cleanSummary.split(" - ");
+		if (dashedMeetingName !== cleanSummary) {
+			meetingName = dashedMeetingName.trim();
+		} else {
+			for (const indicator of MEETING_NAME_INDICATORS) {
+				const index = cleanSummary.indexOf(indicator);
+				if (index > 0) {
+					meetingName = cleanSummary.substring(0, index).trim();
+					break;
+				}
+			}
+		}
+
+		const startTime = Math.floor(calendarEvent.start.getTime() / 1000);
+		const year = new Date(startTime * 1000).getFullYear();
+		const gpName = meetingName
+			.toLowerCase()
+			.replace(/formula\s*1\s*/i, "")
+			.replace(/\d{4}/g, "")
+			.replace(/grand prix/gi, "gp")
+			.trim()
+			.replace(/\s+/g, "-")
+			.replace(/-+/g, "-")
+			.replace(/^-|-$/g, "");
+		events.push({
+			meetingName,
+			eventTypeId: eventType,
+			startTime,
+			eventSlug: `${year}-${gpName}-${EVENT_TYPE_SUFFIXES[eventType]}`,
+		});
+	}
+
+	if (events.length === 0) {
+		console.warn("No F1 events found in the calendar");
+		return;
+	}
+
+	await storeEvents(events);
+	console.log(`Successfully processed ${events.length} F1 events`);
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,88 +2,59 @@ import { config as dotenvConfig } from "dotenv";
 
 dotenvConfig();
 
-/**
- * IRC Bot Configuration
- */
 export interface IRCConfig {
-	// Bot identity
 	nickname: string;
 	nickPassword: string;
 	password: string;
 	realname: string;
 	userInfo: string;
 	source: string;
-
-	// Server connection
 	server: string;
 	port: number;
 	useTls: boolean;
-
-	// Channel settings
 	channels: string[];
-
-	// Bot options
 	commandPrefix: string;
-
-	// Admin settings
 	owners: string[];
 }
 
-/**
- * Database configuration
- */
 export interface DatabaseConfig {
 	url: string;
 	authToken: string;
 }
 
-/**
- * Complete application configuration
- */
 export interface AppConfig {
 	irc: IRCConfig;
 	database: DatabaseConfig;
 	isDevelopment: boolean;
 }
 
-/**
- * Load configuration from environment variables and defaults
- */
 export function loadConfig(): AppConfig {
-	// Determine if we're in development mode
 	const isDevelopment = process.env.NODE_ENV !== "production";
+	const nickname = process.env.IRC_NICKNAME || (isDevelopment ? "HamVerBot-Dev" : "HamVerBot");
+	const channels = process.env.IRC_CHANNELS || (isDevelopment ? "#obviyes" : "#f1");
 
 	return {
 		irc: {
-			nickname: process.env.IRC_NICKNAME || (isDevelopment ? "HamVerBot-Dev" : "HamVerBot"),
+			nickname,
 			nickPassword: process.env.IRC_NICK_PASSWORD || "password",
 			password: process.env.IRC_PASSWORD || "password",
 			realname: process.env.IRC_REALNAME || "Steward of #f1",
 			userInfo: process.env.IRC_USER_INFO || "IRC bot for #f1",
 			source: process.env.IRC_SOURCE || "https://github.com/obviyus/hamverbot",
-
 			server: process.env.IRC_SERVER || "irc.libera.chat",
 			port: Number.parseInt(process.env.IRC_PORT || "6697", 10),
 			useTls: process.env.IRC_USE_TLS !== "false",
-
-			channels: (process.env.IRC_CHANNELS || (isDevelopment ? "#obviyes" : "#f1")).split(","),
-
+			channels: channels.split(","),
 			commandPrefix: process.env.IRC_COMMAND_PREFIX || "!",
-
 			owners: (process.env.IRC_OWNERS || "obviyus").split(","),
 		},
-
 		database: {
 			url: process.env.TURSO_DATABASE_URL || "",
 			authToken: process.env.TURSO_AUTH_TOKEN || "",
 		},
-
 		isDevelopment,
 	};
 }
 
-// Export the default configuration
 export const config = loadConfig();
-
-// Export as default for easier importing
 export default config;

--- a/src/database.ts
+++ b/src/database.ts
@@ -1,4 +1,5 @@
 import { createClient } from "@libsql/client";
+import type { Driver } from "~/types/models";
 import { EventType } from "~/types/event-type";
 
 const EVENT_TYPE_DEFINITIONS = [
@@ -45,43 +46,13 @@ export interface Event {
 	eventSlug: string;
 }
 
-export interface EventResult {
-	id: number;
-	eventId: number;
-	path: string;
-	data: object;
-	createTime: number;
-}
-
-export interface Driver {
-	racingNumber: number;
-	reference: string;
-	firstName: string;
-	lastName: string;
-	fullName: string;
-	broadcastName: string;
-	tla: string;
-	teamName: string;
-	teamColor: string;
-}
-
-export interface DbEvent {
-	id: number;
-	meetingName: string;
-	eventTypeId: EventType;
-	startTime: number;
-}
-
-// Database configuration
 const config = {
 	url: process.env.TURSO_DATABASE_URL,
 	authToken: process.env.TURSO_AUTH_TOKEN,
 };
 
-// Single database instance
 let dbInstance: ReturnType<typeof createClient> | null = null;
 
-// Function to initialize the database
 export async function initDatabase(): Promise<ReturnType<typeof createClient>> {
 	try {
 		if (!config.url || !config.authToken) {
@@ -93,64 +64,45 @@ export async function initDatabase(): Promise<ReturnType<typeof createClient>> {
 			authToken: config.authToken,
 		});
 
-		// Create tables if they don't exist
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS event_type (
+		const schemaStatements = [
+			`CREATE TABLE IF NOT EXISTS event_type (
 				id INTEGER PRIMARY KEY,
 				name VARCHAR(255) NOT NULL UNIQUE
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS events (
+			)`,
+			`CREATE TABLE IF NOT EXISTS events (
 				id INTEGER PRIMARY KEY,
 				meeting_name VARCHAR(255) NOT NULL,
 				event_type_id INTEGER NOT NULL,
 				start_time INTEGER NOT NULL,
 				event_slug VARCHAR(255) NOT NULL UNIQUE,
 				FOREIGN KEY (event_type_id) REFERENCES event_type (id)
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS results (
+			)`,
+			`CREATE TABLE IF NOT EXISTS results (
 				id INTEGER PRIMARY KEY,
 				event_id INTEGER NOT NULL,
 				path VARCHAR(255) NOT NULL UNIQUE,
 				data JSON NOT NULL,
 				create_time INTEGER NOT NULL DEFAULT (unixepoch()),
 				FOREIGN KEY (event_id) REFERENCES events (id)
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS channels (
+			)`,
+			`CREATE TABLE IF NOT EXISTS channels (
 				id INTEGER PRIMARY KEY,
 				name VARCHAR(255) NOT NULL UNIQUE,
 				create_time INTEGER NOT NULL DEFAULT (unixepoch())
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS autopost_channels (
+			)`,
+			`CREATE TABLE IF NOT EXISTS autopost_channels (
 				id INTEGER PRIMARY KEY,
 				name VARCHAR(255) NOT NULL UNIQUE,
 				create_time INTEGER NOT NULL DEFAULT (unixepoch())
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS autopost_seen_messages (
+			)`,
+			`CREATE TABLE IF NOT EXISTS autopost_seen_messages (
 				id INTEGER PRIMARY KEY,
 				session_path VARCHAR(255) NOT NULL,
 				message_key VARCHAR(1024) NOT NULL,
 				create_time INTEGER NOT NULL DEFAULT (unixepoch()),
 				UNIQUE(session_path, message_key)
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS driver_list (
+			)`,
+			`CREATE TABLE IF NOT EXISTS driver_list (
 				racing_number INTEGER PRIMARY KEY,
 				reference VARCHAR(255) NOT NULL,
 				first_name VARCHAR(255) NOT NULL,
@@ -160,49 +112,34 @@ export async function initDatabase(): Promise<ReturnType<typeof createClient>> {
 				tla VARCHAR(255) NOT NULL,
 				team_name VARCHAR(255) NOT NULL,
 				team_color VARCHAR(255) NOT NULL
-			)
-		`);
-
-		await client.execute(`
-			CREATE TABLE IF NOT EXISTS championship_standings (
+			)`,
+			`CREATE TABLE IF NOT EXISTS championship_standings (
 				id INTEGER PRIMARY KEY,
 				type INTEGER NOT NULL UNIQUE,
 				data JSON NOT NULL,
 				create_time INTEGER NOT NULL DEFAULT (unixepoch())
-			)
-		`);
+			)`,
+			`CREATE INDEX IF NOT EXISTS idx_events_start_time
+			ON events (start_time)`,
+			`CREATE INDEX IF NOT EXISTS idx_events_event_type_id_start_time
+			ON events (event_type_id, start_time)`,
+			`CREATE INDEX IF NOT EXISTS idx_events_meeting_name_event_type_id
+			ON events (meeting_name, event_type_id)`,
+			`CREATE INDEX IF NOT EXISTS idx_results_create_time
+			ON results (create_time)`,
+		] as const;
 
-		await client.execute(`
-			CREATE INDEX IF NOT EXISTS idx_events_start_time
-			ON events (start_time)
-		`);
+		for (const statement of schemaStatements) {
+			await client.execute(statement);
+		}
 
-		await client.execute(`
-			CREATE INDEX IF NOT EXISTS idx_events_event_type_id_start_time
-			ON events (event_type_id, start_time)
-		`);
-
-		await client.execute(`
-			CREATE INDEX IF NOT EXISTS idx_events_meeting_name_event_type_id
-			ON events (meeting_name, event_type_id)
-		`);
-
-		await client.execute(`
-			CREATE INDEX IF NOT EXISTS idx_results_create_time
-			ON results (create_time)
-		`);
-
-		// Check if event types already exist
-		const eventTypeCount = await client.execute("SELECT COUNT(*) as count FROM event_type");
-
-		// Only insert event types if none exist
-		if (eventTypeCount.rows[0].count === 0) {
-			for (const type of EVENT_TYPE_DEFINITIONS) {
-				await client.execute({
-					sql: "INSERT INTO event_type (id, name) VALUES (?, ?)",
-					args: [type.id, type.name],
-				});
-			}
+		for (const type of EVENT_TYPE_DEFINITIONS) {
+			await client.execute({
+				sql: `INSERT INTO event_type (id, name)
+					SELECT ?, ?
+					WHERE NOT EXISTS (SELECT 1 FROM event_type WHERE id = ?)`,
+				args: [type.id, type.name, type.id],
+			});
 		}
 
 		return client;
@@ -212,7 +149,6 @@ export async function initDatabase(): Promise<ReturnType<typeof createClient>> {
 	}
 }
 
-// Get or initialize the database instance
 export async function getDb(): Promise<ReturnType<typeof createClient>> {
 	if (!dbInstance) {
 		dbInstance = await initDatabase();
@@ -227,7 +163,22 @@ export async function closeDb(): Promise<void> {
 	}
 }
 
-// Store events in the database
+async function queryExists(sql: string, args: Array<string | number>): Promise<boolean> {
+	const db = await getDb();
+	const result = await db.execute({ sql, args });
+	return result.rows.length > 0;
+}
+
+async function queryStringList(
+	sql: string,
+	column: string,
+	args: Array<string | number> = [],
+): Promise<string[]> {
+	const db = await getDb();
+	const result = args.length === 0 ? await db.execute(sql) : await db.execute({ sql, args });
+	return result.rows.map((row) => row[column] as string);
+}
+
 export async function storeEvents(events: Event[]): Promise<void> {
 	if (events.length === 0) return;
 
@@ -257,11 +208,6 @@ export async function storeEvents(events: Event[]): Promise<void> {
 	}
 }
 
-// Store driver in the database
-export async function storeDriver(driver: Driver): Promise<void> {
-	await storeDrivers([driver]);
-}
-
 export async function storeDrivers(drivers: Driver[]): Promise<void> {
 	if (drivers.length === 0) return;
 
@@ -289,41 +235,6 @@ export async function storeDrivers(drivers: Driver[]): Promise<void> {
 	}
 }
 
-export async function getAllDrivers(): Promise<Driver[]> {
-	try {
-		const db = await getDb();
-		const result = await db.execute(`
-			SELECT 
-				racing_number as racingNumber, 
-				reference, 
-				first_name as firstName, 
-				last_name as lastName, 
-				full_name as fullName, 
-				broadcast_name as broadcastName, 
-				tla, 
-				team_name as teamName, 
-				team_color as teamColor
-			FROM driver_list
-		`);
-
-		return result.rows.map((row) => ({
-			racingNumber: row.racingNumber as number,
-			reference: row.reference as string,
-			firstName: row.firstName as string,
-			lastName: row.lastName as string,
-			fullName: row.fullName as string,
-			broadcastName: row.broadcastName as string,
-			tla: row.tla as string,
-			teamName: row.teamName as string,
-			teamColor: row.teamColor as string,
-		}));
-	} catch (error) {
-		console.error("Error getting all drivers:", error);
-		return [];
-	}
-}
-
-// Get the next event
 export async function getNextEvent(eventType?: EventType): Promise<{
 	meetingName: string;
 	eventType: EventType;
@@ -331,28 +242,19 @@ export async function getNextEvent(eventType?: EventType): Promise<{
 } | null> {
 	try {
 		const db = await getDb();
-
-		// Build query based on parameters
-		let sql = `
+		const args = [eventType ?? null, eventType ?? null];
+		const sql = `
 			SELECT meeting_name, event_type_id, start_time
 			FROM events
 			WHERE start_time > unixepoch()
-		`;
-		const params: (string | number)[] = [];
-
-		if (eventType) {
-			sql += " AND event_type_id = ?";
-			params.push(eventType);
-		}
-
-		sql += `
+				AND (? IS NULL OR event_type_id = ?)
 			ORDER BY start_time
 			LIMIT 1
 		`;
 
-		console.log(`Executing query: ${sql} with params: ${params.join(", ")}`);
+		console.log(`Executing query: ${sql} with params: ${args.join(", ")}`);
 
-		const result = await db.execute({ sql, args: params });
+		const result = await db.execute({ sql, args });
 
 		if (result.rows.length === 0) {
 			console.log("No upcoming events found in database query");
@@ -374,7 +276,6 @@ export async function getNextEvent(eventType?: EventType): Promise<{
 	}
 }
 
-// Get the latest path
 export async function getLatestPath(): Promise<string | null> {
 	try {
 		const db = await getDb();
@@ -396,40 +297,18 @@ export async function getLatestPath(): Promise<string | null> {
 	}
 }
 
-// Check if an event result has been delivered
 export async function isEventDelivered(path: string): Promise<boolean> {
 	try {
-		const db = await getDb();
-		const result = await db.execute({
-			sql: "SELECT 1 FROM results WHERE path = ?",
-			args: [path],
-		});
-
-		return result.rows.length > 0;
+		return queryExists("SELECT 1 FROM results WHERE path = ?", [path]);
 	} catch (error) {
 		console.error("Error checking if event is delivered:", error);
 		return false;
 	}
 }
 
-// Add a channel to the database
-export async function addChannel(channelName: string): Promise<void> {
-	try {
-		const db = await getDb();
-		await db.execute({
-			sql: "INSERT OR IGNORE INTO channels (name) VALUES (?)",
-			args: [channelName],
-		});
-	} catch (error) {
-		console.error("Error adding channel:", error);
-	}
-}
-
 export async function getAllChannels(): Promise<string[]> {
 	try {
-		const db = await getDb();
-		const result = await db.execute("SELECT name FROM channels");
-		return result.rows.map((row) => row.name as string);
+		return queryStringList("SELECT name FROM channels", "name");
 	} catch (error) {
 		console.error("Error getting all channels:", error);
 		return [];
@@ -445,27 +324,21 @@ export async function enableAutopostChannel(channelName: string): Promise<void> 
 }
 
 export async function isAutopostChannelEnabled(channelName: string): Promise<boolean> {
-	const db = await getDb();
-	const result = await db.execute({
-		sql: "SELECT 1 FROM autopost_channels WHERE name = ? LIMIT 1",
-		args: [channelName],
-	});
-	return result.rows.length > 0;
+	return queryExists("SELECT 1 FROM autopost_channels WHERE name = ? LIMIT 1", [channelName]);
 }
 
 export async function getAutopostChannels(): Promise<string[]> {
-	const db = await getDb();
-	const result = await db.execute("SELECT name FROM autopost_channels");
-	return result.rows.map((row) => row.name as string);
+	return queryStringList("SELECT name FROM autopost_channels", "name");
 }
 
 export async function getSeenAutopostMessageKeys(sessionPath: string): Promise<Set<string>> {
-	const db = await getDb();
-	const result = await db.execute({
-		sql: "SELECT message_key FROM autopost_seen_messages WHERE session_path = ?",
-		args: [sessionPath],
-	});
-	return new Set(result.rows.map((row) => row.message_key as string));
+	return new Set(
+		await queryStringList(
+			"SELECT message_key FROM autopost_seen_messages WHERE session_path = ?",
+			"message_key",
+			[sessionPath],
+		),
+	);
 }
 
 export async function markAutopostMessagesSeen(
@@ -497,33 +370,6 @@ export async function storeEventResult(eventId: number, path: string, data: obje
 	}
 }
 
-// Get event by slug
-export async function getEventBySlug(slug: string): Promise<DbEvent | null> {
-	try {
-		const db = await getDb();
-		const result = await db.execute({
-			sql: "SELECT id, meeting_name, event_type_id, start_time FROM events WHERE event_slug = ?",
-			args: [slug],
-		});
-
-		if (result.rows.length === 0) {
-			return null;
-		}
-
-		const row = result.rows[0];
-		return {
-			id: row.id as number,
-			meetingName: row.meeting_name as string,
-			eventTypeId: row.event_type_id as EventType,
-			startTime: row.start_time as number,
-		};
-	} catch (error) {
-		console.error("Error getting event by slug:", error);
-		return null;
-	}
-}
-
-// Get event type name
 export async function getEventTypeName(eventTypeId: EventType): Promise<string> {
 	return EVENT_TYPE_NAMES[eventTypeId] ?? "Unknown";
 }
@@ -544,18 +390,3 @@ export async function storeChampionshipStandings(type: number, data: object): Pr
 	}
 }
 
-// Get championship standings
-export async function getChampionshipStandings(type: number): Promise<object | null> {
-	try {
-		const db = await getDb();
-		const result = await db.execute({
-			sql: "SELECT data FROM championship_standings WHERE type = ? LIMIT 1",
-			args: [type],
-		});
-
-		return result.rows.length > 0 ? JSON.parse(result.rows[0].data as string) : null;
-	} catch (error) {
-		console.error("Error getting championship standings:", error);
-		return null;
-	}
-}

--- a/src/database.ts
+++ b/src/database.ts
@@ -389,4 +389,3 @@ export async function storeChampionshipStandings(type: number, data: object): Pr
 		console.error("Error storing championship standings:", error);
 	}
 }
-

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,8 +8,6 @@ import {
 } from "~/database";
 import type {
 	ConstructorMRData,
-	CurrentConstructorStandings,
-	CurrentDriverStandings,
 	Driver,
 	DriverMRData,
 	DriverStanding,
@@ -17,47 +15,37 @@ import type {
 } from "~/types/models";
 import { sessionKeyToEventType, stringToEventType } from "~/utils/events";
 
-// API endpoints
+type CurrentConstructorStandings = { MRData: ConstructorMRData };
+type CurrentDriverStandings = { MRData: DriverMRData };
+
 const F1_SESSION_ENDPOINT = "https://livetiming.formula1.com/static";
 const ERGAST_API_ENDPOINT = "https://api.jolpi.ca/ergast/f1";
+const SESSION_KEY_ALIASES: Record<string, string> = {
+	practice1: "fp1",
+	practice2: "fp2",
+	practice3: "fp3",
+	sprintshootout: "sprintqualifying",
+	sprintshootoutqualifying: "sprintqualifying",
+};
 
-/**
- * Generic function to fetch JSON data from an API with improved error handling
- */
-async function fetchJson<T>(url: string, headers?: HeadersInit): Promise<T> {
-	try {
-		// Use Bun's native fetch capability
-		const response = await fetch(url, {
-			headers,
-			// Add timeout to prevent hanging requests
-			signal: AbortSignal.timeout(10000),
-		});
+async function fetchJson<T>(url: string): Promise<T> {
+	const response = await fetch(url, {
+		signal: AbortSignal.timeout(10000),
+	});
 
-		if (!response.ok) {
-			throw new Error(`HTTP error! Status: ${response.status} for URL: ${url}`);
-		}
-
-		const text = await response.text();
-
-		// Remove BOM character if present
-		const cleanText = text.trim().replace(/^\uFEFF/, "");
-
-		return JSON.parse(cleanText) as T;
-	} catch (error) {
-		console.error(`Error fetching data from ${url}:`, error);
-		throw error;
+	if (!response.ok) {
+		throw new Error(`HTTP error! Status: ${response.status} for URL: ${url}`);
 	}
+
+	const text = await response.text();
+	const cleanText = text.trim().replace(/^\uFEFF/, "");
+	return JSON.parse(cleanText) as T;
 }
 
-/**
- * Fetch driver list from F1 API and store in database
- */
 export async function fetchDriverList(path: string): Promise<void> {
 	console.log(`Fetching driver list for ${path}...`);
-	const driverListUrl = `${F1_SESSION_ENDPOINT}/${path}DriverList.json`;
 
 	try {
-		// The API response is an object where keys are racing numbers and values are driver data
 		const response = await fetchJson<
 			Record<
 				string,
@@ -73,9 +61,8 @@ export async function fetchDriverList(path: string): Promise<void> {
 					TeamColour: string;
 				}
 			>
-		>(driverListUrl);
+		>(`${F1_SESSION_ENDPOINT}/${path}DriverList.json`);
 
-		// Get all driver entries and process them in a single batch
 		const drivers: Driver[] = Object.values(response).map((driverData) => ({
 			racingNumber: Number.parseInt(driverData.RacingNumber, 10),
 			reference: driverData.Reference || "",
@@ -95,29 +82,21 @@ export async function fetchDriverList(path: string): Promise<void> {
 	}
 }
 
-/**
- * Read current event information from F1 API
- */
 export async function readCurrentEvent(): Promise<{
 	path: string;
 	isComplete: boolean;
 }> {
-	try {
-		const response = await fetchJson<{
-			ArchiveStatus: {
-				Status: string;
-			};
-			Path: string;
-		}>(`${F1_SESSION_ENDPOINT}/SessionInfo.json`);
-
-		return {
-			path: response.Path,
-			isComplete: response.ArchiveStatus.Status === "Complete",
+	const response = await fetchJson<{
+		ArchiveStatus: {
+			Status: string;
 		};
-	} catch (error) {
-		console.error("Error reading current event:", error);
-		throw error;
-	}
+		Path: string;
+	}>(`${F1_SESSION_ENDPOINT}/SessionInfo.json`);
+
+	return {
+		path: response.Path,
+		isComplete: response.ArchiveStatus.Status === "Complete",
+	};
 }
 
 interface TimingLine {
@@ -131,26 +110,14 @@ interface TimingLine {
 	}>;
 }
 
-interface DriverCodeRef {
-	code?: string;
-}
-
-interface RaceResultEntry {
+interface SessionResultEntry {
 	position: string;
-	Driver: DriverCodeRef;
+	Driver: {
+		code?: string;
+	};
 }
 
-interface QualifyingResultEntry {
-	position: string;
-	Driver: DriverCodeRef;
-}
-
-interface RaceEntry {
-	Results?: RaceResultEntry[];
-	QualifyingResults?: QualifyingResultEntry[];
-}
-
-interface RaceTableResponse<T extends RaceEntry> {
+interface RaceTableResponse<T> {
 	MRData: {
 		RaceTable: {
 			season: string;
@@ -159,83 +126,11 @@ interface RaceTableResponse<T extends RaceEntry> {
 	};
 }
 
-/**
- * Extract driver position and timing data from F1 API response
- */
-async function extractPositionAndTiming(data: Record<string, unknown>): Promise<DriverStanding[]> {
-	const lines = data.Lines as Record<string, TimingLine>;
-	if (!lines) {
-		throw new Error("Failed to extract lines from timing data");
-	}
-
-	const db = await getDb();
-
-	// Get all drivers from the database in a single query
-	const result = await db.execute(`
-		SELECT racing_number, tla, team_name 
-		FROM driver_list
-	`);
-
-	const drivers = result.rows.map((row) => ({
-		racing_number: row.racing_number as number,
-		tla: row.tla as string,
-		team_name: row.team_name as string,
-	}));
-
-	const standings: DriverStanding[] = [];
-
-	// Pre-create lookup map for faster driver lookup by racing number
-	const driversMap = new Map(drivers.map((d) => [d.racing_number, d]));
-
-	for (const [_, driverData] of Object.entries(lines)) {
-		if (!driverData.Position || !driverData.RacingNumber) {
-			continue;
-		}
-
-		const position = Number.parseInt(driverData.Position, 10);
-		const racingNumber = Number.parseInt(driverData.RacingNumber, 10);
-
-		// Find the driver using the lookup map
-		const driver = driversMap.get(racingNumber);
-		if (!driver) {
-			console.warn(`Driver with racing number ${racingNumber} not found in database`);
-			continue;
-		}
-
-		// Get best lap time
-		const bestLapTime = driverData.BestLapTime?.Value || "";
-
-		// Get interval to position ahead
-		let difference: string | undefined;
-		if (driverData.Stats && Array.isArray(driverData.Stats)) {
-			const timeDiff = driverData.Stats.find((stat) => stat.TimeDifftoPositionAhead !== undefined);
-			if (timeDiff) {
-				difference = timeDiff.TimeDifftoPositionAhead;
-			}
-		}
-
-		standings.push({
-			position,
-			driverName: driver.tla,
-			teamName: driver.team_name,
-			time: bestLapTime,
-			difference,
-		});
-	}
-
-	// Sort by position
-	return standings.sort((a, b) => a.position - b.position);
-}
-
-/**
- * Fetch results for a given path from the F1 API
- */
 export async function fetchResults(path: string): Promise<string> {
 	console.log(`Fetching results for ${path}...`);
 	const db = await getDb();
 
 	try {
-		// First get the event_id and event_type from the results and events tables
 		const eventQuery = `
 			SELECT e.meeting_name, et.name as event_type_name, r.data
 			FROM results r
@@ -260,8 +155,6 @@ export async function fetchResults(path: string): Promise<string> {
 					throw new Error("Cached result metadata is invalid");
 				}
 				const data = JSON.parse(row.data as string) as SessionResults;
-
-				// Update the title to include the event type from the database
 				sessionResult = {
 					...data,
 					title: `${row.meeting_name}: ${row.event_type_name}`,
@@ -274,100 +167,114 @@ export async function fetchResults(path: string): Promise<string> {
 			sessionResult = await fetchFreshResults(path);
 		}
 
-		return formatResultsOutput(sessionResult);
+		let output = `🏎️ \x02${sessionResult.title} Results\x02:`;
+		for (const standing of sessionResult.standings.slice(0, 10)) {
+			output += ` ${standing.position}. ${standing.driverName} - \x0303[${standing.time}]\x03`;
+		}
+		return output;
 	} catch (error) {
 		console.error("Error fetching results:", error);
 		return `Error fetching results: ${error instanceof Error ? error.message : "Unknown error"}`;
 	}
 }
 
-/**
- * Fetch fresh results from the F1 API
- */
 async function fetchFreshResults(path: string): Promise<SessionResults> {
-	// Fetch timing data
 	console.log(`Fetching TimingDataF1 for ${path}...`);
 	const timingData = await fetchJson<Record<string, unknown>>(
 		`${F1_SESSION_ENDPOINT}/${path}TimingDataF1.json`,
 	);
 
-	// Fetch session info
 	console.log("Fetching SessionInfo...");
 	const sessionInfoResponse = await fetchJson<{
 		Meeting: {
 			OfficialName: string;
-			Name: string;
 		};
 	}>(`${F1_SESSION_ENDPOINT}/SessionInfo.json`);
 
-	// Extract driver standings
-	const standings = await extractPositionAndTiming(timingData);
-
-	// Extract session type from path
-	// Example paths:
-	//   2025/.../2025-09-05_Practice_2/  -> practice2 -> fp2 -> FreePractice2
-	//   2025/.../2025-09-06_Qualifying/  -> qualifying -> Qualifying
-	//   2025/.../2025-09-07_Race/        -> race -> Race
-	//   2025/.../2025-09-06_Sprint_Shootout/ -> sprintshootout -> sprintqualifying
-	const sanitizedPath = path.replace(/\/+$/, "");
-	const lastSegment = sanitizedPath.split("/").filter(Boolean).pop() ?? "";
-	const parts = lastSegment.split("_").filter(Boolean);
-	if (parts.length > 0 && /^\d{4}-\d{2}-\d{2}$/.test(parts[0])) {
-		parts.shift(); // drop leading date component
-	}
-	// Join remaining parts without separators and lowercase
-	let normalizedKey = parts.join("").toLowerCase();
-	// Normalize known variants
-	if (normalizedKey === "practice1") normalizedKey = "fp1";
-	if (normalizedKey === "practice2") normalizedKey = "fp2";
-	if (normalizedKey === "practice3") normalizedKey = "fp3";
-	if (normalizedKey === "sprintshootout" || normalizedKey === "sprintshootoutqualifying") {
-		normalizedKey = "sprintqualifying";
+	const lines = timingData.Lines as Record<string, TimingLine>;
+	if (!lines) {
+		throw new Error("Failed to extract lines from timing data");
 	}
 
-	// Try strict mapping first, then fuzzy mapping as fallback
-	let eventType = normalizedKey ? sessionKeyToEventType(normalizedKey) : null;
-	if (eventType === null && normalizedKey) {
-		const fallback = stringToEventType(normalizedKey);
+	const driverList = await getDb().then((db) =>
+		db.execute(`
+			SELECT racing_number, tla, team_name 
+			FROM driver_list
+		`),
+	);
+	const driversMap = new Map(
+		driverList.rows.map((row) => [row.racing_number as number, { tla: row.tla as string, team_name: row.team_name as string }]),
+	);
+	const standings: DriverStanding[] = [];
+	for (const driverData of Object.values(lines)) {
+		if (!driverData.Position || !driverData.RacingNumber) {
+			continue;
+		}
+
+		const position = Number.parseInt(driverData.Position, 10);
+		const racingNumber = Number.parseInt(driverData.RacingNumber, 10);
+		const driver = driversMap.get(racingNumber);
+		if (!driver) {
+			console.warn(`Driver with racing number ${racingNumber} not found in database`);
+			continue;
+		}
+
+		let difference: string | undefined;
+		if (driverData.Stats && Array.isArray(driverData.Stats)) {
+			difference = driverData.Stats.find((stat) => stat.TimeDifftoPositionAhead !== undefined)
+				?.TimeDifftoPositionAhead;
+		}
+
+		standings.push({
+			position,
+			driverName: driver.tla,
+			teamName: driver.team_name,
+			time: driverData.BestLapTime?.Value || "",
+			difference,
+		});
+	}
+	standings.sort((a, b) => a.position - b.position);
+	const lastSegment = path.replace(/\/+$/, "").split("/").filter(Boolean).at(-1) ?? "";
+	const normalizedKey = lastSegment
+		.split("_")
+		.filter(Boolean)
+		.filter((part, index) => !(index === 0 && /^\d{4}-\d{2}-\d{2}$/.test(part)))
+		.join("")
+		.toLowerCase();
+	const sessionKey = SESSION_KEY_ALIASES[normalizedKey] || normalizedKey;
+
+	let eventType = sessionKey ? sessionKeyToEventType(sessionKey) : null;
+	if (eventType === null && sessionKey) {
+		const fallback = stringToEventType(sessionKey);
 		eventType = typeof fallback === "number" ? fallback : null;
 	}
-	// Prefer DB's canonical event type name ("Practice 1") over utils ("Free Practice 1")
+	const meetingName = sessionInfoResponse.Meeting.OfficialName;
 	const sessionName = eventType !== null ? await getEventTypeName(eventType) : "";
-
-	// Create session result with session type (using only OfficialName)
 	const sessionResult: SessionResults = {
-		title: `${sessionInfoResponse.Meeting.OfficialName}${sessionName ? `: ${sessionName}` : ""}`,
+		title: `${meetingName}${sessionName ? `: ${sessionName}` : ""}`,
 		standings,
 	};
 
 	const db = await getDb();
-	// Try to store results against the correct event (matching meeting name and type)
 	try {
-		if (eventType !== null) {
+		if (eventType === null) {
+			console.warn("Unknown session type in path, skipping result storage for:", path);
+		} else {
 			const exact = await db.execute({
 				sql: "SELECT id FROM events WHERE meeting_name = ? AND event_type_id = ? LIMIT 1",
-				args: [sessionInfoResponse.Meeting.OfficialName, eventType],
+				args: [meetingName, eventType],
 			});
-			if (exact.rows.length > 0) {
-				await storeEventResult(exact.rows[0].id as number, path, sessionResult);
-			} else {
-				// Fallback: try by meeting name only (closest by start time could be added later)
-				const byName = await db.execute({
+			const eventId =
+				exact.rows[0]?.id ??
+				(await db.execute({
 					sql: "SELECT id FROM events WHERE meeting_name = ? LIMIT 1",
-					args: [sessionInfoResponse.Meeting.OfficialName],
-				});
-				if (byName.rows.length > 0) {
-					await storeEventResult(byName.rows[0].id as number, path, sessionResult);
-				} else {
-					console.warn(
-						"Could not find matching event to store results for",
-						sessionInfoResponse.Meeting.OfficialName,
-						eventType,
-					);
-				}
+					args: [meetingName],
+				})).rows[0]?.id;
+			if (eventId) {
+				await storeEventResult(eventId as number, path, sessionResult);
+			} else {
+				console.warn("Could not find matching event to store results for", meetingName, eventType);
 			}
-		} else {
-			console.warn("Unknown session type in path, skipping result storage for:", path);
 		}
 	} catch (e) {
 		console.error("Error while storing event result: ", e);
@@ -376,28 +283,6 @@ async function fetchFreshResults(path: string): Promise<SessionResults> {
 	return sessionResult;
 }
 
-/**
- * Format session results for output
- */
-function formatResultsOutput(sessionResult: SessionResults): string {
-	let output = `🏎️ \x02${sessionResult.title} Results\x02:`;
-
-	// Take only the top 10 drivers to avoid spamming
-	const topDrivers = sessionResult.standings.slice(0, 10);
-
-	for (const standing of topDrivers) {
-		output += ` ${standing.position}. ${standing.driverName} - \x0303[${standing.time}]\x03`;
-	}
-
-	return output;
-}
-
-/**
- * Generic function to fetch standings (WCC or WDC)
- * @param type 0 for WDC, 1 for WCC
- * @param url API endpoint URL
- * @param formatFn Function to format the standings
- */
 async function fetchStandings<T extends object>(
 	type: number,
 	url: string,
@@ -407,25 +292,20 @@ async function fetchStandings<T extends object>(
 	const db = await getDb();
 
 	try {
-		// Check if we already have standings in the database
 		const result = await db.execute({
 			sql: "SELECT data FROM championship_standings WHERE type = ? LIMIT 1",
 			args: [type],
 		});
 
-		let standings: T;
-
-		// If we have standings, use them, otherwise fetch new ones
+		let standings: T | undefined;
 		if (result.rows.length > 0) {
 			try {
 				standings = JSON.parse(result.rows[0].data as string) as T;
 			} catch (error) {
 				console.error("Error parsing cached standings, fetching fresh data:", error);
-				const response = await fetchJson<{ MRData: unknown }>(url);
-				standings = { MRData: response.MRData } as T;
-				await storeChampionshipStandings(type, standings);
 			}
-		} else {
+		}
+		if (!standings) {
 			const response = await fetchJson<{ MRData: unknown }>(url);
 			standings = { MRData: response.MRData } as T;
 			await storeChampionshipStandings(type, standings);
@@ -438,135 +318,74 @@ async function fetchStandings<T extends object>(
 	}
 }
 
-/**
- * Fetch current WCC standings from Jolpica API
- */
+async function fetchCurrentStandings<T extends ConstructorMRData | DriverMRData>(
+	type: number,
+	label: "WCC" | "WDC",
+	url: string,
+): Promise<{ MRData: T } | null> {
+	console.log(`Fetching ${label} standings...`);
+	try {
+		const standings = { MRData: (await fetchJson<{ MRData: T }>(url)).MRData };
+		await storeChampionshipStandings(type, standings);
+		return standings;
+	} catch (error) {
+		console.error(`Error fetching ${label} standings:`, error);
+		return null;
+	}
+}
+
 export async function fetchWccStandings(): Promise<CurrentConstructorStandings | null> {
-	console.log("Fetching WCC standings...");
-	try {
-		const response = await fetchJson<{ MRData: ConstructorMRData }>(
-			`${ERGAST_API_ENDPOINT}/current/constructorstandings/?format=json`,
-		);
-
-		// Convert API response to our model
-		const standings: CurrentConstructorStandings = {
-			MRData: response.MRData,
-		};
-
-		// Store the standings in the database
-		await storeChampionshipStandings(1, standings);
-
-		return standings;
-	} catch (error) {
-		console.error("Error fetching WCC standings:", error);
-		return null;
-	}
+	return fetchCurrentStandings(1, "WCC", `${ERGAST_API_ENDPOINT}/current/constructorstandings/?format=json`);
 }
 
-/**
- * Fetch current WDC standings from Jolpica API
- */
 export async function fetchWdcStandings(): Promise<CurrentDriverStandings | null> {
-	console.log("Fetching WDC standings...");
-	try {
-		const response = await fetchJson<{ MRData: DriverMRData }>(
-			`${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`,
-		);
-
-		// Convert API response to our model
-		const standings: CurrentDriverStandings = {
-			MRData: response.MRData,
-		};
-
-		// Store the standings in the database
-		await storeChampionshipStandings(0, standings);
-
-		return standings;
-	} catch (error) {
-		console.error("Error fetching WDC standings:", error);
-		return null;
-	}
+	return fetchCurrentStandings(0, "WDC", `${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`);
 }
 
-/**
- * Format WCC standings for output
- */
-function formatWccStandings(standings: CurrentConstructorStandings): string {
-	// Format the standings for output
-	let output = `🔧 \x02FORMULA 1 ${standings.MRData.StandingsTable.season} WCC Standings\x02:`;
-
-	// Get the first standings list
-	const standingsList = standings.MRData.StandingsTable.StandingsLists[0];
-	if (!standingsList) {
-		return `No constructor standings yet for the ${standings.MRData.StandingsTable.season} season.`;
-	}
-
-	// Take only the top 10 constructors to avoid spamming
-	const topConstructors = standingsList.ConstructorStandings.slice(0, 10);
-
-	for (const standing of topConstructors) {
-		output += ` ${standing.position}. ${standing.Constructor.name} - \x0303[${standing.points}]\x03`;
-	}
-
-	return output;
-}
-
-/**
- * Format WDC standings for output
- */
-function formatWdcStandings(standings: CurrentDriverStandings): string {
-	// Format the standings for output
-	let output = `🏆 \x02FORMULA 1 ${standings.MRData.StandingsTable.season} WDC Standings\x02:`;
-
-	// Get the first standings list
-	const standingsList = standings.MRData.StandingsTable.StandingsLists[0];
-	if (!standingsList) {
-		return `No driver standings yet for the ${standings.MRData.StandingsTable.season} season.`;
-	}
-
-	// Take only the top 10 drivers to avoid spamming
-	const topDrivers = standingsList.DriverStandings.slice(0, 10);
-
-	for (const standing of topDrivers) {
-		output += ` ${standing.position}. ${standing.Driver.code} - \x0303[${standing.points}]\x03`;
-	}
-
-	return output;
-}
-
-/**
- * Get current WCC standings
- */
 export async function returnWccStandings(): Promise<string | null> {
 	return fetchStandings<CurrentConstructorStandings>(
 		1,
 		`${ERGAST_API_ENDPOINT}/current/constructorstandings/?format=json`,
-		formatWccStandings,
+		(standings) => {
+			let output = `🔧 \x02FORMULA 1 ${standings.MRData.StandingsTable.season} WCC Standings\x02:`;
+			const standingsList = standings.MRData.StandingsTable.StandingsLists[0];
+			if (!standingsList) {
+				return `No constructor standings yet for the ${standings.MRData.StandingsTable.season} season.`;
+			}
+
+			for (const standing of standingsList.ConstructorStandings.slice(0, 10)) {
+				output += ` ${standing.position}. ${standing.Constructor.name} - \x0303[${standing.points}]\x03`;
+			}
+
+			return output;
+		},
 	);
 }
 
-/**
- * Get current WDC standings
- */
 export async function returnWdcStandings(): Promise<string | null> {
 	return fetchStandings<CurrentDriverStandings>(
 		0,
 		`${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`,
-		formatWdcStandings,
+		(standings) => {
+			let output = `🏆 \x02FORMULA 1 ${standings.MRData.StandingsTable.season} WDC Standings\x02:`;
+			const standingsList = standings.MRData.StandingsTable.StandingsLists[0];
+			if (!standingsList) {
+				return `No driver standings yet for the ${standings.MRData.StandingsTable.season} season.`;
+			}
+
+			for (const standing of standingsList.DriverStandings.slice(0, 10)) {
+				output += ` ${standing.position}. ${standing.Driver.code} - \x0303[${standing.points}]\x03`;
+			}
+
+			return output;
+		},
 	);
 }
 
-function findRaceResult(
-	results: RaceResultEntry[] | undefined,
+function findResultByCode<T extends { Driver: { code?: string } }>(
+	results: T[] | undefined,
 	code: string,
-): RaceResultEntry | undefined {
-	return results?.find((result) => result.Driver.code?.toUpperCase() === code);
-}
-
-function findQualifyingResult(
-	results: QualifyingResultEntry[] | undefined,
-	code: string,
-): QualifyingResultEntry | undefined {
+): T | undefined {
 	return results?.find((result) => result.Driver.code?.toUpperCase() === code);
 }
 
@@ -574,10 +393,6 @@ function parsePosition(position: string | undefined): number | null {
 	if (!position) return null;
 	const parsed = Number.parseInt(position, 10);
 	return Number.isNaN(parsed) ? null : parsed;
-}
-
-function formatBestFinish(position: number | null): string {
-	return position ? `P${position}` : "-";
 }
 
 export async function fetchHeadToHead(leftCodeArg: string, rightCodeArg: string): Promise<string> {
@@ -588,10 +403,10 @@ export async function fetchHeadToHead(leftCodeArg: string, rightCodeArg: string)
 		fetchJson<CurrentDriverStandings>(
 			`${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`,
 		),
-		fetchJson<RaceTableResponse<{ Results: RaceResultEntry[] }>>(
+		fetchJson<RaceTableResponse<{ Results: SessionResultEntry[] }>>(
 			`${ERGAST_API_ENDPOINT}/current/results/?format=json&limit=1000`,
 		),
-		fetchJson<RaceTableResponse<{ QualifyingResults: QualifyingResultEntry[] }>>(
+		fetchJson<RaceTableResponse<{ QualifyingResults: SessionResultEntry[] }>>(
 			`${ERGAST_API_ENDPOINT}/current/qualifying/?format=json&limit=1000`,
 		),
 	]);
@@ -601,119 +416,96 @@ export async function fetchHeadToHead(leftCodeArg: string, rightCodeArg: string)
 	const driverStandings = standingsTable.StandingsLists[0]?.DriverStandings ?? [];
 	const races = raceResultsResponse.MRData.RaceTable.Races;
 	const qualifyingSessions = qualifyingResultsResponse.MRData.RaceTable.Races;
-	const hasSeasonData =
-		driverStandings.length > 0 || races.length > 0 || qualifyingSessions.length > 0;
-
-	if (!hasSeasonData) {
+	if (driverStandings.length === 0 && races.length === 0 && qualifyingSessions.length === 0) {
 		return `No H2H data yet for the ${season} season.`;
 	}
 
-	const leftStanding = driverStandings.find(
-		(standing) => standing.Driver.code?.toUpperCase() === leftCode,
+	const standingsByCode = new Map(
+		driverStandings.map((standing) => [standing.Driver.code?.toUpperCase(), standing] as const),
 	);
-	const rightStanding = driverStandings.find(
-		(standing) => standing.Driver.code?.toUpperCase() === rightCode,
-	);
-
+	const leftStanding = standingsByCode.get(leftCode);
 	if (!leftStanding) {
 		return `Unknown driver code: ${leftCode}.`;
 	}
 
+	const rightStanding = standingsByCode.get(rightCode);
 	if (!rightStanding) {
 		return `Unknown driver code: ${rightCode}.`;
 	}
 
-	let leftRaceWins = 0;
-	let rightRaceWins = 0;
-	let leftQualiWins = 0;
-	let rightQualiWins = 0;
-	let leftPodiums = 0;
-	let rightPodiums = 0;
-	let leftBestFinish: number | null = null;
-	let rightBestFinish: number | null = null;
+	const drivers: Array<{
+		standing: (typeof driverStandings)[number];
+		raceWins: number;
+		qualiWins: number;
+		podiums: number;
+		bestFinish: number | null;
+	}> = [
+		{ standing: leftStanding, raceWins: 0, qualiWins: 0, podiums: 0, bestFinish: null },
+		{ standing: rightStanding, raceWins: 0, qualiWins: 0, podiums: 0, bestFinish: null },
+	];
 
 	for (const race of races) {
-		const leftResult = findRaceResult(race.Results, leftCode);
-		const rightResult = findRaceResult(race.Results, rightCode);
-		const leftPosition = parsePosition(leftResult?.position);
-		const rightPosition = parsePosition(rightResult?.position);
+		const positions: [number | null, number | null] = [
+			parsePosition(findResultByCode(race.Results, leftCode)?.position),
+			parsePosition(findResultByCode(race.Results, rightCode)?.position),
+		];
 
-		if (leftPosition !== null) {
-			if (leftPosition <= 3) leftPodiums++;
-			if (leftBestFinish === null || leftPosition < leftBestFinish) {
-				leftBestFinish = leftPosition;
+		for (const [index, position] of positions.entries()) {
+			if (position === null) continue;
+			const driver = drivers[index];
+			if (position <= 3) driver.podiums++;
+			if (driver.bestFinish === null || position < driver.bestFinish) {
+				driver.bestFinish = position;
 			}
 		}
 
-		if (rightPosition !== null) {
-			if (rightPosition <= 3) rightPodiums++;
-			if (rightBestFinish === null || rightPosition < rightBestFinish) {
-				rightBestFinish = rightPosition;
-			}
-		}
-
-		if (leftPosition !== null && rightPosition !== null) {
-			if (leftPosition < rightPosition) leftRaceWins++;
-			if (rightPosition < leftPosition) rightRaceWins++;
+		if (positions[0] !== null && positions[1] !== null) {
+			if (positions[0] < positions[1]) drivers[0].raceWins++;
+			if (positions[1] < positions[0]) drivers[1].raceWins++;
 		}
 	}
 
 	for (const session of qualifyingSessions) {
-		const leftResult = findQualifyingResult(session.QualifyingResults, leftCode);
-		const rightResult = findQualifyingResult(session.QualifyingResults, rightCode);
-		const leftPosition = parsePosition(leftResult?.position);
-		const rightPosition = parsePosition(rightResult?.position);
+		const positions: [number | null, number | null] = [
+			parsePosition(findResultByCode(session.QualifyingResults, leftCode)?.position),
+			parsePosition(findResultByCode(session.QualifyingResults, rightCode)?.position),
+		];
 
-		if (leftPosition !== null && rightPosition !== null) {
-			if (leftPosition < rightPosition) leftQualiWins++;
-			if (rightPosition < leftPosition) rightQualiWins++;
+		if (positions[0] !== null && positions[1] !== null) {
+			if (positions[0] < positions[1]) drivers[0].qualiWins++;
+			if (positions[1] < positions[0]) drivers[1].qualiWins++;
 		}
 	}
 
-	return `⚔️ \x02H2H ${leftCode} vs ${rightCode}\x02 (${season}): Race \x0303${leftRaceWins}-${rightRaceWins}\x03 | Quali \x0303${leftQualiWins}-${rightQualiWins}\x03 | Points \x0303${leftStanding.points}-${rightStanding.points}\x03 | Podiums \x0303${leftPodiums}-${rightPodiums}\x03 | Best finish \x0303${formatBestFinish(leftBestFinish)}/${formatBestFinish(rightBestFinish)}\x03`;
+	return `⚔️ \x02H2H ${leftCode} vs ${rightCode}\x02 (${season}): Race \x0303${drivers[0].raceWins}-${drivers[1].raceWins}\x03 | Quali \x0303${drivers[0].qualiWins}-${drivers[1].qualiWins}\x03 | Points \x0303${drivers[0].standing.points}-${drivers[1].standing.points}\x03 | Podiums \x0303${drivers[0].podiums}-${drivers[1].podiums}\x03 | Best finish \x0303${drivers[0].bestFinish ? `P${drivers[0].bestFinish}` : "-"}/${drivers[1].bestFinish ? `P${drivers[1].bestFinish}` : "-"}\x03`;
 }
 
-/**
- * Fetch the next closest event from the database
- */
 export async function fetchNextEvent(): Promise<string | null> {
 	console.log("Checking for upcoming events...");
 
-	try {
-		// Get the next event from the database
-		const nextEvent = await getNextEvent();
-		if (!nextEvent) {
-			console.log("No upcoming events found in database");
-			return null;
-		}
+	const nextEvent = await getNextEvent();
+	if (!nextEvent) {
+		console.log("No upcoming events found in database");
+		return null;
+	}
 
-		const { meetingName, eventType, startTime } = nextEvent;
-		console.log(
-			`Found upcoming event: ${meetingName}, type: ${eventType}, time: ${new Date(startTime * 1000).toISOString()}`,
-		);
+	const { meetingName, eventType, startTime } = nextEvent;
+	const eventTime = startTime * 1000;
+	const timeToEventMinutes = Math.floor((eventTime - Date.now()) / (1000 * 60));
 
-		// Convert Unix timestamp to Date
-		const eventDate = new Date(startTime * 1000);
+	console.log(
+		`Found upcoming event: ${meetingName}, type: ${eventType}, time: ${new Date(eventTime).toISOString()}`,
+	);
+	console.log(`Time to event: ${timeToEventMinutes} minutes`);
 
-		const timeToEventMinutes = Math.floor((eventDate.getTime() - Date.now()) / (1000 * 60));
-		console.log(`Time to event: ${timeToEventMinutes} minutes`);
-
-		// Only notify if the event is starting in the next 5 minutes
-		if (timeToEventMinutes > 0 && timeToEventMinutes <= 5) {
-			// Get the event type name
-			const eventTypeName = await getEventTypeName(eventType);
-			console.log(
-				`Event starting soon! Preparing notification for ${meetingName}: ${eventTypeName}`,
-			);
-			return `🏎️ \x02${meetingName}: ${eventTypeName}\x02 begins in 5 minutes.`;
-		}
-
+	if (timeToEventMinutes <= 0 || timeToEventMinutes > 5) {
 		console.log(
 			`Event not starting soon (${timeToEventMinutes} minutes away), no notification needed`,
 		);
 		return null;
-	} catch (error) {
-		console.error("Error fetching next event:", error);
-		return null;
 	}
+
+	const eventTypeName = await getEventTypeName(eventType);
+	console.log(`Event starting soon! Preparing notification for ${meetingName}: ${eventTypeName}`);
+	return `🏎️ \x02${meetingName}: ${eventTypeName}\x02 begins in 5 minutes.`;
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -203,7 +203,10 @@ async function fetchFreshResults(path: string): Promise<SessionResults> {
 		`),
 	);
 	const driversMap = new Map(
-		driverList.rows.map((row) => [row.racing_number as number, { tla: row.tla as string, team_name: row.team_name as string }]),
+		driverList.rows.map((row) => [
+			row.racing_number as number,
+			{ tla: row.tla as string, team_name: row.team_name as string },
+		]),
 	);
 	const standings: DriverStanding[] = [];
 	for (const driverData of Object.values(lines)) {
@@ -221,8 +224,9 @@ async function fetchFreshResults(path: string): Promise<SessionResults> {
 
 		let difference: string | undefined;
 		if (driverData.Stats && Array.isArray(driverData.Stats)) {
-			difference = driverData.Stats.find((stat) => stat.TimeDifftoPositionAhead !== undefined)
-				?.TimeDifftoPositionAhead;
+			difference = driverData.Stats.find(
+				(stat) => stat.TimeDifftoPositionAhead !== undefined,
+			)?.TimeDifftoPositionAhead;
 		}
 
 		standings.push({
@@ -266,10 +270,12 @@ async function fetchFreshResults(path: string): Promise<SessionResults> {
 			});
 			const eventId =
 				exact.rows[0]?.id ??
-				(await db.execute({
-					sql: "SELECT id FROM events WHERE meeting_name = ? LIMIT 1",
-					args: [meetingName],
-				})).rows[0]?.id;
+				(
+					await db.execute({
+						sql: "SELECT id FROM events WHERE meeting_name = ? LIMIT 1",
+						args: [meetingName],
+					})
+				).rows[0]?.id;
 			if (eventId) {
 				await storeEventResult(eventId as number, path, sessionResult);
 			} else {
@@ -335,11 +341,19 @@ async function fetchCurrentStandings<T extends ConstructorMRData | DriverMRData>
 }
 
 export async function fetchWccStandings(): Promise<CurrentConstructorStandings | null> {
-	return fetchCurrentStandings(1, "WCC", `${ERGAST_API_ENDPOINT}/current/constructorstandings/?format=json`);
+	return fetchCurrentStandings(
+		1,
+		"WCC",
+		`${ERGAST_API_ENDPOINT}/current/constructorstandings/?format=json`,
+	);
 }
 
 export async function fetchWdcStandings(): Promise<CurrentDriverStandings | null> {
-	return fetchCurrentStandings(0, "WDC", `${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`);
+	return fetchCurrentStandings(
+		0,
+		"WDC",
+		`${ERGAST_API_ENDPOINT}/current/driverstandings/?format=json`,
+	);
 }
 
 export async function returnWccStandings(): Promise<string | null> {

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -5,94 +5,6 @@ import { handleIrcMessage } from "./message";
 
 type Client = IRC.Client;
 
-// Define event types based on the documentation
-interface LoggedInEvent {
-	nick: string;
-	ident: string;
-	hostname: string;
-	account: string;
-	time: number;
-	tags: Record<string, string>;
-}
-
-interface SaslFailedEvent {
-	reason: string;
-	message?: string;
-	nick?: string;
-	time?: number;
-	tags?: Record<string, string>;
-}
-
-interface ServerOptionsEvent {
-	options: Record<string, unknown>;
-	cap: Record<string, unknown>;
-}
-
-interface JoinEvent {
-	nick: string;
-	ident: string;
-	hostname: string;
-	channel: string;
-	time: number;
-	account?: string;
-}
-
-interface PartEvent {
-	nick: string;
-	ident: string;
-	hostname: string;
-	channel: string;
-	message?: string;
-	time: number;
-}
-
-interface QuitEvent {
-	nick: string;
-	ident: string;
-	hostname: string;
-	message?: string;
-	time: number;
-}
-
-interface TopicEvent {
-	channel: string;
-	topic: string;
-	nick?: string;
-	time?: number;
-}
-
-interface CtcpRequestEvent {
-	nick: string;
-	ident: string;
-	hostname: string;
-	target: string;
-	type: string;
-	message: string;
-	time: number;
-	account?: string;
-}
-
-interface NoticeEvent {
-	from_server: boolean;
-	nick?: string;
-	ident?: string;
-	hostname?: string;
-	target: string;
-	group?: string;
-	message: string;
-	tags: Record<string, string>;
-	time: number;
-	account?: string;
-}
-
-// Type for IRC client network capabilities
-interface IrcNetwork {
-	cap: {
-		enabled: string[];
-		isEnabled: (cap: string) => boolean;
-	};
-}
-
 interface IrcClientConfig {
 	server: string;
 	port: number;
@@ -105,124 +17,58 @@ interface IrcClientConfig {
 	channels?: string[];
 }
 
-// Default IRC port if not specified
 const DEFAULT_IRC_PORT = 6667;
 const LIBERA_HOST_REGEX = /(^|\.)libera\.chat$/i;
 const IRC_MAX_LINE_BYTES = 510;
 
-// Global client instance
 let ircClient: Client | null = null;
-
-// Track authentication status
 let isAuthenticated = false;
-
-// Track whether the IRC server registration handshake completed.
 let isRegistered = false;
-
-// Store authentication callbacks
-const readyCallbacks: (() => void)[] = [];
-
-// Track whether a join callback is registered for the next ready cycle.
-let joinOnReadyRegistered = false;
-
-// Store configured channels for reconnect joins.
+let shouldJoinOnReady = false;
 let configuredChannels: string[] = [];
 
 function hasConfiguredNickPassword(nickPassword?: string): nickPassword is string {
 	return !!nickPassword && nickPassword !== "password";
 }
 
-function getSaslAccount(
-	nickname: string,
-	nickPassword?: string,
-): { account: string; password: string } | undefined {
-	if (!hasConfiguredNickPassword(nickPassword)) return undefined;
-	return { account: nickname, password: nickPassword };
-}
-
-async function resolveJoinChannels(): Promise<string[]> {
-	const dbChannels = await getAllChannels();
-	return configuredChannels.concat(dbChannels);
-}
-
-function shouldUseBunTlsIpv4Workaround(server: string, secure?: boolean): boolean {
-	// AIDEV-NOTE: Bun TLS + Libera can throw a subject-destructure error unless IPv4 is forced.
-	return typeof Bun !== "undefined" && !!secure && LIBERA_HOST_REGEX.test(server);
-}
-
-function isClientReady(): boolean {
-	return isRegistered && isAuthenticated;
-}
-
-/**
- * Register a callback to be executed after the connection is ready for joins.
- */
-export function onReady(callback: () => void): void {
-	if (isClientReady()) {
-		callback();
-		return;
-	}
-
-	readyCallbacks.push(callback);
-}
-
-/**
- * Ensure we re-join channels after registration and authentication.
- */
-function registerJoinOnReady(reason: string): void {
-	if (joinOnReadyRegistered) return;
-	joinOnReadyRegistered = true;
-
-	// AIDEV-NOTE: Re-register join-on-ready per reconnect; ready callbacks are one-shot.
-	onReady(async () => {
-		joinOnReadyRegistered = false;
-		console.log(`Connection ready (${reason}), joining channels...`);
-		const channels = await resolveJoinChannels();
-		joinChannels(channels);
-	});
-}
-
-/**
- * Execute all registered ready callbacks
- */
-function executeReadyCallbacks(): void {
-	let callback: (() => void) | undefined;
-	while ((callback = readyCallbacks.shift())) callback();
-}
-
 function maybeMarkReady(client: Client): void {
-	if (!isClientReady()) return;
+	if (!isRegistered || !isAuthenticated) return;
 
-	setBotMode(client);
-	executeReadyCallbacks();
-}
-
-function markAuthenticated(client: Client, logMessage: string): void {
-	isAuthenticated = true;
-	console.log(logMessage);
-	maybeMarkReady(client);
-}
-
-function markRegistered(client: Client, nickPassword?: string): void {
-	isRegistered = true;
-	console.log("Connected to IRC server...");
-	if (!hasConfiguredNickPassword(nickPassword)) {
-		isAuthenticated = true;
-		console.log("No authentication required, ready to join channels");
+	try {
+		client.raw(`MODE ${client.user.nick} +B`);
+		console.log(`Set bot mode (+B) for ${client.user.nick}`);
+	} catch (error) {
+		console.error("Failed to set bot mode:", error);
 	}
-	maybeMarkReady(client);
+	if (!shouldJoinOnReady) return;
+
+	shouldJoinOnReady = false;
+	void (async () => {
+		console.log("Connection ready, joining channels...");
+		for (const channel of configuredChannels.concat(await getAllChannels())) {
+			client.join(channel);
+			console.log(`Joined channel: ${channel}`);
+		}
+	})();
 }
 
 function resetConnectionState(): void {
 	isAuthenticated = false;
 	isRegistered = false;
-	joinOnReadyRegistered = false;
-	readyCallbacks.length = 0;
+	shouldJoinOnReady = false;
 }
 
-function connectClient(client: Client, config: IrcClientConfig): void {
-	const useBunTlsIpv4Workaround = shouldUseBunTlsIpv4Workaround(config.server, config.secure);
+function createAndConnectClient(config: IrcClientConfig): Client {
+	resetConnectionState();
+	const client = new IRC.Client();
+	ircClient = client;
+	configuredChannels = config.channels || [];
 
+	initEventListeners(client, config.nickname, config.nickPassword);
+	shouldJoinOnReady = true;
+
+	const useBunTlsIpv4Workaround =
+		typeof Bun !== "undefined" && !!config.secure && LIBERA_HOST_REGEX.test(config.server);
 	console.log("IRC Configuration:");
 	console.log(`  Server: ${config.server}:${config.port}`);
 	console.log(`  Nickname: ${config.nickname}`);
@@ -245,29 +91,15 @@ function connectClient(client: Client, config: IrcClientConfig): void {
 		auto_reconnect: true,
 		auto_reconnect_max_retries: 30,
 		auto_reconnect_max_wait: 30000,
-		account: getSaslAccount(config.nickname, config.nickPassword),
+		account: hasConfiguredNickPassword(config.nickPassword)
+			? { account: config.nickname, password: config.nickPassword }
+			: undefined,
 		...(useBunTlsIpv4Workaround ? { outgoing_addr: "0.0.0.0" } : {}),
 	});
-}
-
-function createAndConnectClient(config: IrcClientConfig, joinReason: string): Client {
-	resetConnectionState();
-	const client = new IRC.Client();
-	ircClient = client;
-	configuredChannels = config.channels || [];
-
-	initEventListeners(client, config.nickname, config.nickPassword);
-	registerJoinOnReady(joinReason);
-	connectClient(client, config);
 
 	return client;
 }
 
-/**
- * Get the IRC client instance
- * @returns The IRC client instance
- * @throws Error if the client is not initialized
- */
 export function getClient(): Client {
 	if (!ircClient) {
 		throw new Error("IRC client not initialized. Call initIrcClient first.");
@@ -275,128 +107,53 @@ export function getClient(): Client {
 	return ircClient;
 }
 
-/**
- * Check if the IRC client is initialized and connected
- * @returns True if the client is initialized and connected, false otherwise
- */
-export function isClientConnected(): boolean {
-	return !!ircClient && ircClient.connected;
-}
-
-/**
- * Check if the client is authenticated with NickServ
- * @returns True if authenticated, false otherwise
- */
 export function isClientAuthenticated(): boolean {
 	return isAuthenticated;
 }
 
-function sendWithLogging(target: string, message: string, privateMessage = false): void {
+function sendWithLogging(target: string, message: string): void {
 	const client = getClient();
-	const normalizedMessage = normalizeOutgoingMessage(target, message);
-	try {
-		client.say(target, normalizedMessage);
-		if (privateMessage) {
-			console.log(`Private message sent to ${target}`);
-		} else {
-			console.log(`Message sent to ${target}: ${normalizedMessage}`);
+	const sanitized = message.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+	const maxBytes = IRC_MAX_LINE_BYTES - Buffer.byteLength(`PRIVMSG ${target} :`);
+	let normalizedMessage = sanitized;
+	if (Buffer.byteLength(sanitized) > maxBytes) {
+		const ellipsis = "...";
+		const maxContentBytes = Math.max(0, maxBytes - Buffer.byteLength(ellipsis));
+		for (const pattern of [/ \| /g, / \d+\.\s/g, / /g]) {
+			let bestIndex = -1;
+			for (const match of sanitized.matchAll(pattern)) {
+				const index = match.index ?? -1;
+				if (index <= 0) continue;
+				if (Buffer.byteLength(sanitized.slice(0, index).trimEnd()) > maxContentBytes) continue;
+				bestIndex = index;
+			}
+			if (bestIndex > 0) {
+				normalizedMessage = `${sanitized.slice(0, bestIndex).trimEnd()}${ellipsis}`;
+				break;
+			}
 		}
-	} catch (error) {
-		if (privateMessage) {
-			console.error(`Error sending private message to ${target}:`, error);
-		} else {
-			console.error(`Error sending message to ${target}:`, error);
+
+		if (normalizedMessage === sanitized) {
+			let truncated = "";
+			for (const char of sanitized) {
+				if (Buffer.byteLength(truncated) + Buffer.byteLength(char) > maxContentBytes) break;
+				truncated += char;
+			}
+			normalizedMessage = `${truncated.trimEnd()}${ellipsis}`;
 		}
 	}
-}
-
-function normalizeWhitespace(message: string): string {
-	return message.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
-}
-
-function getMaxPrivmsgBytes(target: string): number {
-	return IRC_MAX_LINE_BYTES - Buffer.byteLength(`PRIVMSG ${target} :`);
-}
-
-function truncateToBytes(message: string, maxBytes: number): string {
-	if (Buffer.byteLength(message) <= maxBytes) return message;
-
-	const ellipsis = "...";
-	const maxContentBytes = Math.max(0, maxBytes - Buffer.byteLength(ellipsis));
-	const boundaryIndex = findPreferredBoundaryIndex(message, maxContentBytes);
-	if (boundaryIndex > 0) {
-		return `${message.slice(0, boundaryIndex).trimEnd()}${ellipsis}`;
-	}
-
-	let truncated = "";
-	for (const char of message) {
-		if (Buffer.byteLength(truncated) + Buffer.byteLength(char) > maxContentBytes) break;
-		truncated += char;
-	}
-
-	return `${truncated.trimEnd()}${ellipsis}`;
-}
-
-function findPreferredBoundaryIndex(message: string, maxBytes: number): number {
-	const structuredBoundaryIndex = findLastMatchingIndex(message, maxBytes, [
-		...findSeparatorIndexes(message, " | "),
-		...findNumberedItemIndexes(message),
-	]);
-	if (structuredBoundaryIndex > 0) return structuredBoundaryIndex;
-
-	return findLastMatchingIndex(message, maxBytes, findWhitespaceIndexes(message));
-}
-
-function findLastMatchingIndex(message: string, maxBytes: number, indexes: number[]): number {
-	let bestIndex = -1;
-
-	for (const index of indexes) {
-		if (index <= 0) continue;
-		if (Buffer.byteLength(message.slice(0, index).trimEnd()) > maxBytes) continue;
-		if (index > bestIndex) bestIndex = index;
-	}
-
-	return bestIndex;
-}
-
-function findSeparatorIndexes(message: string, separator: string): number[] {
-	const indexes: number[] = [];
-	let searchFrom = 0;
-
-	while (searchFrom < message.length) {
-		const index = message.indexOf(separator, searchFrom);
-		if (index === -1) break;
-		indexes.push(index);
-		searchFrom = index + separator.length;
-	}
-
-	return indexes;
-}
-
-function findNumberedItemIndexes(message: string): number[] {
-	return Array.from(message.matchAll(/ \d+\.\s/g), (match) => match.index ?? -1);
-}
-
-function findWhitespaceIndexes(message: string): number[] {
-	return Array.from(message.matchAll(/ /g), (match) => match.index ?? -1);
-}
-
-function normalizeOutgoingMessage(target: string, message: string): string {
-	const sanitized = normalizeWhitespace(message);
-	const maxBytes = getMaxPrivmsgBytes(target);
-	const normalized = truncateToBytes(sanitized, maxBytes);
-
-	if (normalized !== sanitized) {
+	if (normalizedMessage !== sanitized) {
 		console.warn(`Truncated outbound IRC message for ${target} to ${maxBytes} bytes`);
 	}
 
-	return normalized;
+	try {
+		client.say(target, normalizedMessage);
+		console.log(`Message sent to ${target}: ${normalizedMessage}`);
+	} catch (error) {
+		console.error(`Error sending message to ${target}:`, error);
+	}
 }
 
-/**
- * Broadcast a message to all registered channels
- * @param message - The message to broadcast
- */
 export async function broadcast(message: string): Promise<void> {
 	const channels = await getAllChannels();
 
@@ -405,37 +162,19 @@ export async function broadcast(message: string): Promise<void> {
 	}
 }
 
-/**
- * Initialize the IRC client with the given configuration
- * @param config - The IRC client configuration
- * @returns The initialized IRC client
- */
 export async function initIrcClient(config: IrcClientConfig): Promise<Client> {
-	return createAndConnectClient(config, "initial connect");
+	return createAndConnectClient(config);
 }
 
-function dispatchCommand(
-	message: string,
-	target: string,
-	nick: string,
-	commandContext: string,
-	isPrivate: boolean,
-): void {
+function dispatchCommand(message: string, target: string, nick: string, isPrivate: boolean): void {
 	if (!message.startsWith(appConfig.irc.commandPrefix)) return;
 	const commandText = message.slice(appConfig.irc.commandPrefix.length);
 	void handleIrcMessage(commandText, { target, nick, isPrivate }).catch((error) => {
-		console.error(`Error handling ${commandContext} command:`, error);
+		console.error("Error handling command:", error);
 	});
 }
 
-/**
- * Initialize event listeners for the IRC client
- * @param client - The IRC client
- * @param nickname - The bot's nickname
- * @param nickPassword - The NickServ password (optional)
- */
 function initEventListeners(client: Client, nickname: string, nickPassword?: string): void {
-	// Bun >=1.1.27 can emit idle timeouts even with active traffic; disable the raw socket timeout.
 	client.on("socket connected", () => {
 		const transport = (
 			client as unknown as {
@@ -453,12 +192,9 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 		}
 	});
 
-	// Handle successful registration with the server
 	client.on("registered", () => {
-		// If SASL is not being used, fall back to NickServ authentication
 		if (hasConfiguredNickPassword(nickPassword)) {
-			// Check if SASL capability is enabled - if not, use NickServ
-			const clientWithNetwork = client as Client & { network?: IrcNetwork };
+			const clientWithNetwork = client as Client & { network?: { cap?: { enabled?: string[] } } };
 			const caps = clientWithNetwork.network?.cap?.enabled || [];
 			if (!caps.includes("sasl")) {
 				isRegistered = true;
@@ -468,51 +204,47 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 			}
 		}
 
-		markRegistered(client, nickPassword);
+		isRegistered = true;
+		console.log("Connected to IRC server...");
+		if (!hasConfiguredNickPassword(nickPassword)) {
+			isAuthenticated = true;
+			console.log("No authentication required, ready to join channels");
+		}
+		maybeMarkReady(client);
 	});
 
-	// Handle SASL login events
 	client.on("loggedin", (event: unknown) => {
-		const loggedInEvent = event as LoggedInEvent;
-		markAuthenticated(client, `Successfully authenticated with SASL as ${loggedInEvent.account}`);
+		isAuthenticated = true;
+		console.log(`Successfully authenticated with SASL as ${(event as { account: string }).account}`);
+		maybeMarkReady(client);
 	});
 
-	// Handle SASL failure
 	client.on("sasl failed", (event: unknown) => {
-		const saslFailedEvent = event as SaslFailedEvent;
-		console.error(`SASL authentication failed: ${saslFailedEvent.reason}`);
-
-		// Fall back to NickServ if SASL fails and we have a password
+		console.error(`SASL authentication failed: ${(event as { reason: string }).reason}`);
 		if (hasConfiguredNickPassword(nickPassword)) {
 			console.log("Falling back to NickServ authentication");
 			authenticateWithNickServ(nickname, nickPassword);
 		}
 	});
 
-	// Handle nickname already in use
 	client.on("nick in use", () => {
 		const altNick = `${nickname}_`;
 		console.log(`Nickname ${nickname} in use, trying ${altNick}`);
 		client.changeNick(altNick);
 	});
 
-	// Handle errors
 	client.on("error", (error: unknown) => {
 		console.error("IRC client error:", error);
 	});
 
-	// Handle connection close
 	client.on("close", () => {
 		console.log("Connection closed. Attempting to reconnect...");
 		resetConnectionState();
 	});
 
-	// Handle socket errors
 	client.on("socket close", (err: unknown) => {
 		const error = err as { message?: string; code?: string; errno?: number } | undefined;
 		console.log("Socket closed:", error?.message || "No error");
-
-		// Log additional details if available
 		if (error) {
 			if (error.code) console.log("Socket close code:", error.code);
 			if (error.errno) console.log("Socket close errno:", error.errno);
@@ -520,58 +252,44 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 		}
 
 		resetConnectionState();
-
-		// Log connection status
 		console.log(
 			"Connection status after socket close:",
 			client.connected ? "Still connected" : "Disconnected",
 		);
 		console.log("Auto reconnect is enabled, will attempt to reconnect shortly...");
-
 	});
 
-	// Handle reconnections
 	client.on("reconnecting", (opts: unknown) => {
 		const options = opts as { wait: number };
 		console.log(`Reconnecting to IRC server in ${options.wait / 1000} seconds...`);
-		registerJoinOnReady("reconnect");
+		shouldJoinOnReady = true;
 	});
 
-	// Handle successful reconnection
-	client.on("connected", async () => {
+	client.on("connected", () => {
 		console.log("Successfully reconnected to IRC server");
 	});
 
-	// Handle ping timeouts
 	client.on("ping timeout", () => {
 		console.warn("Ping timeout detected. Connection may be unstable.");
 	});
 
-	// Handle server options
 	client.on("server options", (options: unknown) => {
-		const serverOptions = options as ServerOptionsEvent;
-		console.log("Server options received:", JSON.stringify(serverOptions));
+		console.log("Server options received:", JSON.stringify(options));
 	});
 
-	// Handle messages
 	client.on("message", (event) => {
-		// Special handling for NickServ messages to help debug authentication
 		if (event.nick === "NickServ") {
 			console.log(`[NickServ] ${event.message}`);
-
-			// Check for successful authentication
 			if (
 				event.message.includes("You are now identified") ||
 				event.message.includes("You are already logged in")
 			) {
-				markAuthenticated(client, "Successfully authenticated with NickServ");
-			}
-			// Handle NickServ authentication failures
-			else if (event.message.includes("Invalid password")) {
+				isAuthenticated = true;
+				console.log("Successfully authenticated with NickServ");
+				maybeMarkReady(client);
+			} else if (event.message.includes("Invalid password")) {
 				console.error("NickServ authentication failed: Invalid password");
 				console.error("Please check your IRC_NICK_PASSWORD environment variable");
-
-				// Generate a random nickname as fallback
 				const altNick = `${nickname}_${Math.floor(Math.random() * 1000)}`;
 				console.log(`Switching to alternative nickname: ${altNick}`);
 				client.changeNick(altNick);
@@ -583,21 +301,18 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 			console.log(`[${event.target}] ${event.nick}: ${event.message}`);
 		}
 
-		// Handle commands
-		dispatchCommand(event.message, event.target, event.nick, "channel", false);
+		dispatchCommand(event.message, event.target, event.nick, false);
 	});
 
-	// Handle private messages
 	client.on("privmsg", (event) => {
 		if (event.target === nickname) {
 			console.log(`[PM] ${event.nick}: ${event.message}`);
-			dispatchCommand(event.message, event.nick, event.nick, "private", true);
+			dispatchCommand(event.message, event.nick, event.nick, true);
 		}
 	});
 
-	// Handle notices
 	client.on("notice", (event: unknown) => {
-		const noticeEvent = event as NoticeEvent;
+		const noticeEvent = event as { from_server: boolean; nick?: string; message: string };
 		if (noticeEvent.from_server) {
 			console.log(`[Server Notice] ${noticeEvent.message}`);
 		} else {
@@ -605,122 +320,43 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 		}
 	});
 
-	// Handle channel joins
 	client.on("join", (event: unknown) => {
-		const joinEvent = event as JoinEvent;
+		const joinEvent = event as { nick: string; channel: string };
 		console.log(`${joinEvent.nick} joined ${joinEvent.channel}`);
 	});
 
-	// Handle channel parts
 	client.on("part", (event: unknown) => {
-		const partEvent = event as PartEvent;
-		console.log(
-			`${partEvent.nick} left ${partEvent.channel}: ${partEvent.message || "No message"}`,
-		);
+		const partEvent = event as { nick: string; channel: string; message?: string };
+		console.log(`${partEvent.nick} left ${partEvent.channel}: ${partEvent.message || "No message"}`);
 	});
 
-	// Handle user quits
 	client.on("quit", (event: unknown) => {
-		const quitEvent = event as QuitEvent;
+		const quitEvent = event as { nick: string; message?: string };
 		console.log(`${quitEvent.nick} quit: ${quitEvent.message || "No message"}`);
 	});
 
-	// Handle topic changes
 	client.on("topic", (event: unknown) => {
-		const topicEvent = event as TopicEvent;
+		const topicEvent = event as { channel: string; topic: string };
 		console.log(`Topic for ${topicEvent.channel}: ${topicEvent.topic}`);
 	});
 
-	// Handle CTCP requests
 	client.on("ctcp request", (event: unknown) => {
-		const ctcpEvent = event as CtcpRequestEvent;
+		const ctcpEvent = event as { nick: string; type: string; message: string };
 		console.log(`CTCP ${ctcpEvent.type} request from ${ctcpEvent.nick}: ${ctcpEvent.message}`);
 	});
 }
 
-/**
- * Authenticate with NickServ
- * @param nickname - The bot's nickname
- * @param password - The NickServ password
- */
 function authenticateWithNickServ(nickname: string, password: string): void {
 	const client = getClient();
-
-	// Log authentication attempt (without showing the actual password)
 	console.log(`Attempting to authenticate with NickServ for nickname: ${nickname}`);
-
-	// The correct format is: IDENTIFY <password>
-	// NickServ expects just the password, not the nickname and password
 	client.say("NickServ", `IDENTIFY ${password}`);
-
 	console.log("Sent authentication to NickServ");
 }
 
-/**
- * Join a channel
- * @param channel - The channel to join
- */
-export function joinChannel(channel: string): void {
-	const client = getClient();
-	client.join(channel);
-	console.log(`Joined channel: ${channel}`);
-}
-
-/**
- * Join multiple channels
- * @param channels - The channels to join
- */
-export function joinChannels(channels: string[]): void {
-	for (const channel of channels) {
-		joinChannel(channel);
-	}
-}
-
-/**
- * Leave a channel
- * @param channel - The channel to leave
- */
-export function leaveChannel(channel: string): void {
-	const client = getClient();
-	client.part(channel);
-	console.log(`Left channel: ${channel}`);
-}
-
-/**
- * Send a message to a specific channel
- * @param channel - The channel to send the message to
- * @param message - The message to send
- */
 export function sendMessage(channel: string, message: string): void {
 	sendWithLogging(channel, message);
 }
 
-/**
- * Send a private message to a user
- * @param nickname - The nickname to send the message to
- * @param message - The message to send
- */
-export function sendPrivateMessage(nickname: string, message: string): void {
-	sendWithLogging(nickname, message, true);
-}
-
-/**
- * Disconnect from the IRC server
- * @param message - Optional quit message
- */
-export function disconnect(message?: string): void {
-	const client = getClient();
-	client.quit(message || "Disconnecting");
-	ircClient = null;
-	resetConnectionState();
-	console.log("Disconnected from IRC server");
-}
-
-/**
- * Manually attempt to reconnect to the IRC server
- * This is a fallback for when the auto-reconnect doesn't work
- * @returns Promise that resolves when reconnection is attempted
- */
 export async function attemptManualReconnect(): Promise<boolean> {
 	console.log("Attempting manual reconnection to IRC server...");
 
@@ -730,26 +366,23 @@ export async function attemptManualReconnect(): Promise<boolean> {
 	}
 
 	try {
-		// If we're already connected, no need to reconnect
 		if (ircClient.connected) {
 			console.log("Already connected, no need to reconnect");
 			return true;
 		}
 
-		createAndConnectClient(
-			{
-				server: appConfig.irc.server,
-				port: appConfig.irc.port,
-				nickname: appConfig.irc.nickname,
-				username: appConfig.irc.nickname,
-				realname: appConfig.irc.realname,
-				password: appConfig.irc.password,
-				nickPassword: appConfig.irc.nickPassword,
-				secure: appConfig.irc.useTls,
-				channels: appConfig.irc.channels,
-			},
-			"manual reconnect",
-		);
+		const { irc } = appConfig;
+		createAndConnectClient({
+			server: irc.server,
+			port: irc.port,
+			nickname: irc.nickname,
+			username: irc.nickname,
+			realname: irc.realname,
+			password: irc.password,
+			nickPassword: irc.nickPassword,
+			secure: irc.useTls,
+			channels: irc.channels,
+		});
 
 		console.log("Manual reconnection initiated");
 		return true;
@@ -759,15 +392,3 @@ export async function attemptManualReconnect(): Promise<boolean> {
 	}
 }
 
-/**
- * Set the bot mode (+B) for the client
- * @param client - The IRC client
- */
-function setBotMode(client: Client): void {
-	try {
-		client.raw(`MODE ${client.user.nick} +B`);
-		console.log(`Set bot mode (+B) for ${client.user.nick}`);
-	} catch (error) {
-		console.error("Failed to set bot mode:", error);
-	}
-}

--- a/src/irc.ts
+++ b/src/irc.ts
@@ -113,7 +113,10 @@ export function isClientAuthenticated(): boolean {
 
 function sendWithLogging(target: string, message: string): void {
 	const client = getClient();
-	const sanitized = message.replace(/[\r\n]+/g, " ").replace(/\s+/g, " ").trim();
+	const sanitized = message
+		.replace(/[\r\n]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
 	const maxBytes = IRC_MAX_LINE_BYTES - Buffer.byteLength(`PRIVMSG ${target} :`);
 	let normalizedMessage = sanitized;
 	if (Buffer.byteLength(sanitized) > maxBytes) {
@@ -215,7 +218,9 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 
 	client.on("loggedin", (event: unknown) => {
 		isAuthenticated = true;
-		console.log(`Successfully authenticated with SASL as ${(event as { account: string }).account}`);
+		console.log(
+			`Successfully authenticated with SASL as ${(event as { account: string }).account}`,
+		);
 		maybeMarkReady(client);
 	});
 
@@ -327,7 +332,9 @@ function initEventListeners(client: Client, nickname: string, nickPassword?: str
 
 	client.on("part", (event: unknown) => {
 		const partEvent = event as { nick: string; channel: string; message?: string };
-		console.log(`${partEvent.nick} left ${partEvent.channel}: ${partEvent.message || "No message"}`);
+		console.log(
+			`${partEvent.nick} left ${partEvent.channel}: ${partEvent.message || "No message"}`,
+		);
 	});
 
 	client.on("quit", (event: unknown) => {
@@ -391,4 +398,3 @@ export async function attemptManualReconnect(): Promise<boolean> {
 		return false;
 	}
 }
-

--- a/src/live-timing.ts
+++ b/src/live-timing.ts
@@ -134,17 +134,15 @@ interface LiveTimingSnapshot {
 type LiveTimingTopic = Exclude<keyof LiveTimingSnapshot, "SessionInfo">;
 
 export function createLiveTimingConnection(): LiveTimingConnection {
-	return (
-		new signalR.HubConnectionBuilder()
-			.withUrl(F1_SIGNALR_ENDPOINT, {
-				httpClient: new BunSignalRHttpClient(),
-				transport: signalR.HttpTransportType.WebSockets,
-				withCredentials: true,
-				timeout: 10000,
-			})
-			.configureLogging(signalR.LogLevel.Error)
-			.build()
-	);
+	return new signalR.HubConnectionBuilder()
+		.withUrl(F1_SIGNALR_ENDPOINT, {
+			httpClient: new BunSignalRHttpClient(),
+			transport: signalR.HttpTransportType.WebSockets,
+			withCredentials: true,
+			timeout: 10000,
+		})
+		.configureLogging(signalR.LogLevel.Error)
+		.build();
 }
 
 function formatSessionTitle(session: CurrentSessionInfo): string {

--- a/src/live-timing.ts
+++ b/src/live-timing.ts
@@ -12,7 +12,6 @@ interface CurrentSessionInfo {
 	};
 	Name: string;
 	Path: string;
-	SessionStatus?: string;
 }
 
 export interface RaceControlMessage {
@@ -24,10 +23,6 @@ export interface RaceControlMessage {
 	Mode?: string;
 }
 
-interface RaceControlMessagesResponse {
-	Messages: RaceControlMessage[];
-}
-
 interface LiveTimingConnection {
 	start(): Promise<void>;
 	stop(): Promise<void>;
@@ -36,10 +31,6 @@ interface LiveTimingConnection {
 
 class BunSignalRHttpClient extends signalR.HttpClient {
 	private readonly cookies = new Map<string, string>();
-
-	getCookieString(): string {
-		return [...this.cookies.values()].join("; ");
-	}
 
 	private rememberCookies(response: Response): void {
 		const rawCookies = response.headers.get("set-cookie");
@@ -78,7 +69,7 @@ class BunSignalRHttpClient extends signalR.HttpClient {
 					? AbortSignal.timeout(request.timeout)
 					: abortController.signal;
 
-		const cookieHeader = this.getCookieString();
+		const cookieHeader = [...this.cookies.values()].join("; ");
 		const response = await fetch(request.url, {
 			method: request.method,
 			body: request.content as BodyInit | null | undefined,
@@ -110,42 +101,34 @@ class BunSignalRHttpClient extends signalR.HttpClient {
 	}
 }
 
-interface WeatherData {
-	AirTemp: string;
-	Humidity: string;
-	Rainfall: string;
-	TrackTemp: string;
-	WindDirection: string;
-	WindSpeed: string;
-}
-
-interface SessionDriver {
-	RacingNumber: string;
-	Tla: string;
-}
-
-interface TimingStint {
-	Compound: string;
-	New: boolean | string;
-	TotalLaps: number | string;
-}
-
-interface TimingAppLine {
-	RacingNumber: string;
-	Line: number;
-	Stints: TimingStint[];
-}
-
-interface TimingAppDataResponse {
-	Lines: Record<string, TimingAppLine>;
-}
-
 interface LiveTimingSnapshot {
-	RaceControlMessages?: RaceControlMessagesResponse;
+	RaceControlMessages?: {
+		Messages: RaceControlMessage[];
+	};
 	SessionInfo?: CurrentSessionInfo;
-	WeatherData?: WeatherData;
-	DriverList?: Record<string, SessionDriver>;
-	TimingAppData?: TimingAppDataResponse;
+	WeatherData?: {
+		AirTemp: string;
+		Humidity: string;
+		Rainfall: string;
+		TrackTemp: string;
+		WindDirection: string;
+		WindSpeed: string;
+	};
+	DriverList?: Record<string, { RacingNumber: string; Tla: string }>;
+	TimingAppData?: {
+		Lines: Record<
+			string,
+			{
+				RacingNumber: string;
+				Line: number;
+				Stints: Array<{
+					Compound: string;
+					New: boolean | string;
+					TotalLaps: number | string;
+				}>;
+			}
+		>;
+	};
 }
 
 type LiveTimingTopic = Exclude<keyof LiveTimingSnapshot, "SessionInfo">;
@@ -153,7 +136,6 @@ type LiveTimingTopic = Exclude<keyof LiveTimingSnapshot, "SessionInfo">;
 export function createLiveTimingConnection(): LiveTimingConnection {
 	return (
 		new signalR.HubConnectionBuilder()
-			// AIDEV-NOTE: live topics come from SignalR while archive generation is in flight; completed sessions fall back to static JSON.
 			.withUrl(F1_SIGNALR_ENDPOINT, {
 				httpClient: new BunSignalRHttpClient(),
 				transport: signalR.HttpTransportType.WebSockets,
@@ -240,51 +222,32 @@ async function fetchJson<T>(url: string): Promise<T> {
 	return data;
 }
 
-async function fetchCurrentSessionInfo(): Promise<CurrentSessionInfo> {
-	return fetchJson<CurrentSessionInfo>(`${F1_STATIC_ENDPOINT}/SessionInfo.json`);
-}
-
-async function fetchSignalRSnapshot(
-	topics: Array<keyof LiveTimingSnapshot>,
-	createConnection: () => LiveTimingConnection = createLiveTimingConnection,
-): Promise<LiveTimingSnapshot> {
-	const connection = createConnection();
-
-	try {
-		await connection.start();
-		return await connection.invoke<LiveTimingSnapshot>("Subscribe", topics);
-	} finally {
-		await connection.stop();
-	}
-}
-
-async function fetchStaticSnapshot(
-	session: CurrentSessionInfo,
-	topics: LiveTimingTopic[],
-): Promise<LiveTimingSnapshot> {
-	const entries = await Promise.all(
-		topics.map(async (topic) => {
-			const data = await fetchOptionalJson(`${F1_STATIC_ENDPOINT}/${session.Path}${topic}.json`);
-			return [topic, data] as const;
-		}),
-	);
-
-	return Object.fromEntries([
-		["SessionInfo", session],
-		...entries.filter((entry): entry is [LiveTimingTopic, unknown] => entry[1] !== undefined),
-	]) as LiveTimingSnapshot;
-}
-
 async function fetchCurrentSessionSnapshot(
 	topics: LiveTimingTopic[],
 	createConnection: () => LiveTimingConnection = createLiveTimingConnection,
 ): Promise<LiveTimingSnapshot> {
-	const session = await fetchCurrentSessionInfo();
+	const session = await fetchJson<CurrentSessionInfo>(`${F1_STATIC_ENDPOINT}/SessionInfo.json`);
 	if (session.ArchiveStatus.Status === "Complete") {
-		return await fetchStaticSnapshot(session, topics);
+		const entries = await Promise.all(
+			topics.map(async (topic) => {
+				const data = await fetchOptionalJson(`${F1_STATIC_ENDPOINT}/${session.Path}${topic}.json`);
+				return [topic, data] as const;
+			}),
+		);
+
+		return Object.fromEntries([
+			["SessionInfo", session],
+			...entries.filter((entry): entry is [LiveTimingTopic, unknown] => entry[1] !== undefined),
+		]) as LiveTimingSnapshot;
 	}
 
-	return await fetchSignalRSnapshot(["SessionInfo", ...topics], createConnection);
+	const connection = createConnection();
+	try {
+		await connection.start();
+		return connection.invoke<LiveTimingSnapshot>("Subscribe", ["SessionInfo", ...topics]);
+	} finally {
+		await connection.stop();
+	}
 }
 
 export async function fetchCurrentSessionRaceControlMessages(

--- a/src/message.ts
+++ b/src/message.ts
@@ -28,9 +28,8 @@ function parseTimezone(arg?: string): number | undefined {
 	if (!arg) return undefined;
 
 	const normalized = arg.toLowerCase();
-	const offset = normalized.startsWith("utc") || normalized.startsWith("gmt")
-		? normalized.slice(3)
-		: normalized;
+	const offset =
+		normalized.startsWith("utc") || normalized.startsWith("gmt") ? normalized.slice(3) : normalized;
 	if (offset === "") return 0;
 
 	const match = /^([+-]?)(\d{1,2})(?::(\d{1,2}))?$/.exec(offset);
@@ -77,9 +76,7 @@ async function getNextEventMessage(eventType?: EventType, timezone?: number): Pr
 	const timeLeftString = [
 		days > 0 ? `${days} day${days === 1 ? "" : "s"}` : null,
 		hours > 0 || days > 0 ? `${hours} hour${hours === 1 ? "" : "s"}` : null,
-		minutes > 0 || hours > 0 || days > 0
-			? `${minutes} minute${minutes === 1 ? "" : "s"}`
-			: null,
+		minutes > 0 || hours > 0 || days > 0 ? `${minutes} minute${minutes === 1 ? "" : "s"}` : null,
 	]
 		.filter((part): part is string => part !== null)
 		.join(" and ");
@@ -118,9 +115,13 @@ const commandHandlers: Record<string, CommandHandler> = {
 		return fetchResults(path);
 	}),
 
-	drivers: withErrorReply("Error fetching WDC standings", "Failed to fetch standings.", async () => {
-		return (await returnWdcStandings()) || "No standings available.";
-	}),
+	drivers: withErrorReply(
+		"Error fetching WDC standings",
+		"Failed to fetch standings.",
+		async () => {
+			return (await returnWdcStandings()) || "No standings available.";
+		},
+	),
 
 	constructors: withErrorReply(
 		"Error fetching WCC standings",
@@ -155,31 +156,39 @@ const commandHandlers: Record<string, CommandHandler> = {
 		return fetchSessionStints();
 	}),
 
-	enable: withErrorReply("Error enabling autopost", "Failed to enable autopost.", async (args, context) => {
-		if (args[0] !== "autopost") {
-			return "Usage: !enable autopost";
-		}
+	enable: withErrorReply(
+		"Error enabling autopost",
+		"Failed to enable autopost.",
+		async (args, context) => {
+			if (args[0] !== "autopost") {
+				return "Usage: !enable autopost";
+			}
 
-		if (context.isPrivate) {
-			return "Run this in the channel you want to enable.";
-		}
+			if (context.isPrivate) {
+				return "Run this in the channel you want to enable.";
+			}
 
-		if (!appConfig.irc.owners.some((owner) => owner.trim().toLowerCase() === context.nick.toLowerCase())) {
-			return "Only bot owners can enable autopost.";
-		}
+			if (
+				!appConfig.irc.owners.some(
+					(owner) => owner.trim().toLowerCase() === context.nick.toLowerCase(),
+				)
+			) {
+				return "Only bot owners can enable autopost.";
+			}
 
-		if (await isAutopostChannelEnabled(context.target)) {
-			return "Autopost already enabled here.";
-		}
+			if (await isAutopostChannelEnabled(context.target)) {
+				return "Autopost already enabled here.";
+			}
 
-		const { session, messages } = await fetchCurrentSessionRaceControlMessages();
-		const relevantMessageKeys = messages
-			.filter(shouldAutopostRaceControlMessage)
-			.map(buildRaceControlMessageKey);
-		await markAutopostMessagesSeen(session.Path, relevantMessageKeys);
-		await enableAutopostChannel(context.target);
-		return `Autopost enabled in ${context.target}. Watching red flags, safety car, penalties.`;
-	}),
+			const { session, messages } = await fetchCurrentSessionRaceControlMessages();
+			const relevantMessageKeys = messages
+				.filter(shouldAutopostRaceControlMessage)
+				.map(buildRaceControlMessageKey);
+			await markAutopostMessagesSeen(session.Path, relevantMessageKeys);
+			await enableAutopostChannel(context.target);
+			return `Autopost enabled in ${context.target}. Watching red flags, safety car, penalties.`;
+		},
+	),
 
 	help: async () => {
 		return "Available commands: !ping, !next [timezone], !when [event] [timezone], !prev, !drivers, !constructors, !h2h VER HAM, !weather, !stints, !enable autopost, !help";

--- a/src/message.ts
+++ b/src/message.ts
@@ -24,258 +24,113 @@ interface CommandContext {
 	isPrivate: boolean;
 }
 
-/**
- * Parse a timezone argument string (e.g., "utc+1", "gmt-5:30", "+1", "-5:30")
- * @param arg - The timezone argument string
- * @returns The parsed timezone offset in minutes or undefined if invalid
- */
 function parseTimezone(arg?: string): number | undefined {
 	if (!arg) return undefined;
 
-	// Convert to lowercase for case-insensitive comparison
-	const lowerArg = arg.toLowerCase();
+	const normalized = arg.toLowerCase();
+	const offset = normalized.startsWith("utc") || normalized.startsWith("gmt")
+		? normalized.slice(3)
+		: normalized;
+	if (offset === "") return 0;
 
-	// Handle prefixed case (utc/gmt)
-	if (lowerArg.startsWith("utc") || lowerArg.startsWith("gmt")) {
-		// Handle UTC/GMT+0 case
-		const offsetStr = lowerArg.substring(3);
-		if (offsetStr.length === 0) {
-			return 0;
-		}
+	const match = /^([+-]?)(\d{1,2})(?::(\d{1,2}))?$/.exec(offset);
+	if (!match) return undefined;
 
-		return parseOffset(offsetStr);
-	}
-
-	// No prefix, try to parse directly
-	return parseOffset(lowerArg);
-}
-
-/**
- * Parse an offset string like "+1", "-5:30"
- * @param offsetStr - The offset string to parse
- * @returns The offset in minutes or undefined if invalid
- */
-function parseOffset(offsetStr: string): number | undefined {
-	// Parse sign and offset
-	const firstChar = offsetStr.charAt(0);
-	const sign = firstChar === "-" ? -1 : 1;
-
-	// Skip sign character if present
-	const offsetValue = firstChar === "+" || firstChar === "-" ? offsetStr.substring(1) : offsetStr;
-
-	// Parse hours and optional minutes
-	const parts = offsetValue.split(":");
-
-	let seconds: number;
-	if (parts.length === 1) {
-		// Just hours
-		const hours = Number.parseInt(parts[0], 10);
-		if (Number.isNaN(hours) || !isValidHoursOffset(hours * sign)) return undefined;
-		seconds = hours * 3600;
-	} else if (parts.length === 2) {
-		// Hours and minutes
-		const hours = Number.parseInt(parts[0], 10);
-		const minutes = Number.parseInt(parts[1], 10);
-		if (Number.isNaN(hours) || !isValidHoursOffset(hours * sign)) return undefined;
-		if (Number.isNaN(minutes) || !isValidMinutesOffset(minutes)) return undefined;
-		seconds = hours * 3600 + minutes * 60;
-	} else {
+	const sign = match[1] === "-" ? -1 : 1;
+	const hours = Number.parseInt(match[2], 10) * sign;
+	const minutes = Number.parseInt(match[3] || "0", 10);
+	if (hours < -12 || hours > 14 || minutes < 0 || minutes > 59) {
 		return undefined;
 	}
 
-	return (seconds * sign) / 60;
+	return hours * 60 + minutes * sign;
 }
 
-/**
- * Check if the hours offset is within valid range (from -12 to +14)
- * @param signedOffset - A signed hours offset
- * @returns True if the offset is within the range
- */
-function isValidHoursOffset(signedOffset: number): boolean {
-	const minHoursOffset = -12,
-		maxHoursOffset = 14;
+async function getNextEventMessage(eventType?: EventType, timezone?: number): Promise<string> {
+	const event = await getNextEvent(eventType);
+	if (!event) {
+		return "No upcoming events found.";
+	}
 
-	return signedOffset >= minHoursOffset && signedOffset <= maxHoursOffset;
-}
-
-/**
- * Check if the minutes offset is within valid range (from 0 to 59)
- * @param minutes - A minutes offset
- * @returns True if minutes are within the range
- */
-function isValidMinutesOffset(minutes: number): boolean {
-	const minMinutesOffset = 0,
-		maxMinutesOffset = 59;
-
-	return minutes >= minMinutesOffset && minutes <= maxMinutesOffset;
-}
-
-/**
- * Build a time string for an event
- * @param eventName - The name of the event
- * @param eventTime - The timestamp of the event
- * @param timezone - Optional timezone offset in minutes
- * @returns The formatted time string
- */
-function buildTimeString(eventName: string, eventTime: number, timezone?: number): string {
-	const eventDate = new Date(eventTime * 1000);
-
+	const eventName = `${eventTypeToEmoji(event.eventType)} ${event.meetingName}: ${eventTypeToString(event.eventType)}`;
+	const eventDate = new Date(event.startTime * 1000);
 	if (timezone !== undefined) {
-		// Convert to the specified timezone
-		const offsetMinutes = timezone;
-		const localTime = new Date(eventDate.getTime() + offsetMinutes * 60 * 1000);
-
-		// Format the timezone string
-		const tzHours = Math.abs(Math.floor(offsetMinutes / 60));
-		const tzMinutes = Math.abs(offsetMinutes % 60);
-		const tzSign = offsetMinutes >= 0 ? "+" : "-";
+		const localTime = new Date(eventDate.getTime() + timezone * 60 * 1000);
+		const tzHours = Math.abs(Math.floor(timezone / 60));
+		const tzMinutes = Math.abs(timezone % 60);
+		const tzSign = timezone >= 0 ? "+" : "-";
 		const tzStr = `${tzSign}${tzHours.toString().padStart(2, "0")}:${tzMinutes.toString().padStart(2, "0")}`;
-
-		// Format the date: "Day, Month Date"
 		const dateStr = localTime.toUTCString().split(" ").slice(0, 3).join(" ");
 
 		return `\x02${eventName}\x02 starts on ${dateStr} at ${localTime.getUTCHours().toString().padStart(2, "0")}:${localTime.getUTCMinutes().toString().padStart(2, "0")} UTC${tzStr}`;
 	}
 
-	// Calculate time left
-	const timeLeft = eventDate.getTime() - Date.now();
-	const timeLeftString = formatDuration(timeLeft);
+	const durationMs = eventDate.getTime() - Date.now();
+	if (durationMs <= 0) {
+		return `\x02${eventName}\x02 begins in 0 seconds`;
+	}
+
+	const totalMinutes = Math.floor(durationMs / 60000);
+	const days = Math.floor(totalMinutes / (24 * 60));
+	const hours = Math.floor(totalMinutes / 60) % 24;
+	const minutes = totalMinutes % 60;
+	const timeLeftString = [
+		days > 0 ? `${days} day${days === 1 ? "" : "s"}` : null,
+		hours > 0 || days > 0 ? `${hours} hour${hours === 1 ? "" : "s"}` : null,
+		minutes > 0 || hours > 0 || days > 0
+			? `${minutes} minute${minutes === 1 ? "" : "s"}`
+			: null,
+	]
+		.filter((part): part is string => part !== null)
+		.join(" and ");
 
 	return `\x02${eventName}\x02 begins in ${timeLeftString}`;
 }
 
-/**
- * Format a duration in milliseconds to a human-readable string
- * @param durationMs - The duration in milliseconds
- * @returns The formatted duration string
- */
-function formatDuration(durationMs: number): string {
-	if (durationMs <= 0) {
-		return "0 seconds";
-	}
+type CommandHandler = (args: string[], context: CommandContext) => Promise<string>;
 
-	const seconds = Math.floor(durationMs / 1000);
-	const days = Math.floor(seconds / 86400);
-	const hours = Math.floor((seconds % 86400) / 3600);
-	const minutes = Math.floor((seconds % 3600) / 60);
-
-	const durationParts: string[] = [];
-
-	if (days > 0) {
-		durationParts.push(`${days} ${pluralize("day", days)}`);
-	}
-
-	if (hours > 0 || durationParts.length > 0) {
-		durationParts.push(`${hours} ${pluralize("hour", hours)}`);
-	}
-
-	if (minutes > 0 || durationParts.length > 0) {
-		durationParts.push(`${minutes} ${pluralize("minute", minutes)}`);
-	}
-
-	return durationParts.join(" and ");
+function withErrorReply(
+	errorLabel: string,
+	failureMessage: string,
+	handler: CommandHandler,
+): CommandHandler {
+	return (args, context) => {
+		return handler(args, context).catch((error) => {
+			console.error(`${errorLabel}:`, error);
+			return failureMessage;
+		});
+	};
 }
 
-/**
- * Pluralize a word based on count
- * @param word - The word to pluralize
- * @param count - The count
- * @returns The pluralized word
- */
-function pluralize(word: string, count: number): string {
-	return `${word}${count === 1 ? "" : "s"}`;
-}
-
-/**
- * Get next event and format response message
- */
-async function getNextEventMessage(eventType?: EventType, timezone?: number): Promise<string> {
-	const event = await getNextEvent(eventType);
-
-	if (!event) {
-		return "No upcoming events found.";
-	}
-
-	const { meetingName, eventType: type, startTime } = event;
-	const emoji = eventTypeToEmoji(type);
-	return buildTimeString(
-		`${emoji} ${meetingName}: ${eventTypeToString(type)}`,
-		startTime,
-		timezone,
-	);
-}
-
-// Command handler functions
-function isOwnerNick(nick: string): boolean {
-	return appConfig.irc.owners.some((owner) => owner.trim().toLowerCase() === nick.toLowerCase());
-}
-
-async function enableAutopost(target: string): Promise<string> {
-	if (await isAutopostChannelEnabled(target)) {
-		return "Autopost already enabled here.";
-	}
-
-	const { session, messages } = await fetchCurrentSessionRaceControlMessages();
-	const relevantMessageKeys = messages
-		.filter(shouldAutopostRaceControlMessage)
-		.map(buildRaceControlMessageKey);
-
-	await markAutopostMessagesSeen(session.Path, relevantMessageKeys);
-	await enableAutopostChannel(target);
-
-	return `Autopost enabled in ${target}. Watching red flags, safety car, penalties.`;
-}
-
-const commandHandlers: Record<
-	string,
-	(args: string[], context: CommandContext) => Promise<string>
-> = {
+const commandHandlers: Record<string, CommandHandler> = {
 	ping: async () => "pong",
 
-	next: async (args) => {
-		const timezone = parseTimezone(args[0]);
-		return await getNextEventMessage(undefined, timezone);
-	},
+	next: async (args) => getNextEventMessage(undefined, parseTimezone(args[0])),
 
-	when: async (args) => {
-		const eventType = stringToEventType(args[0]);
-		const timezone = parseTimezone(args[1]);
-		return await getNextEventMessage(eventType, timezone);
-	},
+	when: async (args) => getNextEventMessage(stringToEventType(args[0]), parseTimezone(args[1])),
 
-	prev: async () => {
+	prev: withErrorReply("Error fetching results", "Failed to fetch results.", async () => {
 		const path = await getLatestPath();
 		if (!path) {
 			return "No previous events found.";
 		}
 
-		try {
-			return await fetchResults(path);
-		} catch (error) {
-			console.error("Error fetching results:", error);
-			return "Failed to fetch results.";
-		}
-	},
+		return fetchResults(path);
+	}),
 
-	drivers: async () => {
-		try {
-			return (await returnWdcStandings()) || "No standings available.";
-		} catch (error) {
-			console.error("Error fetching WDC standings:", error);
-			return "Failed to fetch standings.";
-		}
-	},
+	drivers: withErrorReply("Error fetching WDC standings", "Failed to fetch standings.", async () => {
+		return (await returnWdcStandings()) || "No standings available.";
+	}),
 
-	constructors: async () => {
-		try {
+	constructors: withErrorReply(
+		"Error fetching WCC standings",
+		"Failed to fetch standings.",
+		async () => {
 			return (await returnWccStandings()) || "No standings available.";
-		} catch (error) {
-			console.error("Error fetching WCC standings:", error);
-			return "Failed to fetch standings.";
-		}
-	},
+		},
+	),
 
-	h2h: async (args) => {
+	h2h: withErrorReply("Error fetching H2H", "Failed to fetch H2H.", async (args) => {
 		if (args.length !== 2) {
 			return "Usage: !h2h VER HAM";
 		}
@@ -289,33 +144,18 @@ const commandHandlers: Record<
 			return "Pick two different drivers.";
 		}
 
-		try {
-			return await fetchHeadToHead(leftCode, rightCode);
-		} catch (error) {
-			console.error("Error fetching H2H:", error);
-			return "Failed to fetch H2H.";
-		}
-	},
+		return fetchHeadToHead(leftCode, rightCode);
+	}),
 
-	weather: async () => {
-		try {
-			return await fetchSessionWeather();
-		} catch (error) {
-			console.error("Error fetching weather:", error);
-			return "Failed to fetch weather.";
-		}
-	},
+	weather: withErrorReply("Error fetching weather", "Failed to fetch weather.", async () => {
+		return fetchSessionWeather();
+	}),
 
-	stints: async () => {
-		try {
-			return await fetchSessionStints();
-		} catch (error) {
-			console.error("Error fetching stints:", error);
-			return "Failed to fetch stints.";
-		}
-	},
+	stints: withErrorReply("Error fetching stints", "Failed to fetch stints.", async () => {
+		return fetchSessionStints();
+	}),
 
-	enable: async (args, context) => {
+	enable: withErrorReply("Error enabling autopost", "Failed to enable autopost.", async (args, context) => {
 		if (args[0] !== "autopost") {
 			return "Usage: !enable autopost";
 		}
@@ -324,24 +164,28 @@ const commandHandlers: Record<
 			return "Run this in the channel you want to enable.";
 		}
 
-		if (!isOwnerNick(context.nick)) {
+		if (!appConfig.irc.owners.some((owner) => owner.trim().toLowerCase() === context.nick.toLowerCase())) {
 			return "Only bot owners can enable autopost.";
 		}
 
-		try {
-			return await enableAutopost(context.target);
-		} catch (error) {
-			console.error("Error enabling autopost:", error);
-			return "Failed to enable autopost.";
+		if (await isAutopostChannelEnabled(context.target)) {
+			return "Autopost already enabled here.";
 		}
-	},
+
+		const { session, messages } = await fetchCurrentSessionRaceControlMessages();
+		const relevantMessageKeys = messages
+			.filter(shouldAutopostRaceControlMessage)
+			.map(buildRaceControlMessageKey);
+		await markAutopostMessagesSeen(session.Path, relevantMessageKeys);
+		await enableAutopostChannel(context.target);
+		return `Autopost enabled in ${context.target}. Watching red flags, safety car, penalties.`;
+	}),
 
 	help: async () => {
 		return "Available commands: !ping, !next [timezone], !when [event] [timezone], !prev, !drivers, !constructors, !h2h VER HAM, !weather, !stints, !enable autopost, !help";
 	},
 };
 
-// Command aliases
 const commandAliases: Record<string, string> = {
 	n: "next",
 	w: "when",
@@ -351,11 +195,6 @@ const commandAliases: Record<string, string> = {
 	h: "help",
 };
 
-/**
- * Handle an IRC message
- * @param message - The message text
- * @param context - The IRC command context
- */
 export async function handleIrcMessage(message: string, context: CommandContext): Promise<void> {
 	console.log(`Processing command: ${message} from ${context.nick} in ${context.target}`);
 

--- a/src/types/event-type.ts
+++ b/src/types/event-type.ts
@@ -1,6 +1,3 @@
-/**
- * Event types for F1 sessions
- */
 export enum EventType {
 	LiveryReveal = 1,
 	FreePractice1 = 2,

--- a/src/types/irc-framework.d.ts
+++ b/src/types/irc-framework.d.ts
@@ -1,89 +1,18 @@
 declare module "irc-framework" {
-	interface WhoisEvent {
-		nick: string;
-		ident: string;
-		hostname: string;
-		actual_ip?: string;
-		actual_hostname?: string;
-		real_name?: string;
-		server?: string;
-		server_info?: string;
-		idle?: string;
-		account?: string;
-		secure?: string;
-		away?: string;
-		operator?: string;
-		channels?: string;
-		modes?: string;
-		helpop?: string;
-		bot?: string;
-		logon?: string;
-		registered_nick?: string;
-		special?: string;
-	}
-
-	interface WhoEvent {
-		target: string;
-		users: Array<{
-			nick: string;
-			ident: string;
-			hostname: string;
-			away?: boolean;
-			real_name?: string;
-		}>;
-		tags: Record<string, string>;
-	}
-
-	// Define IRC event types
 	interface IrcMessageEvent {
 		nick: string;
-		ident: string;
-		hostname: string;
 		target: string;
 		message: string;
-		tags: Record<string, string>;
-		time?: number;
-		account?: string;
-		type?: string;
-	}
-
-	interface IrcRegisteredEvent {
-		nick: string;
-	}
-
-	interface IrcErrorEvent {
-		error: string;
-		reason?: string;
-	}
-
-	interface IrcCloseEvent {
-		wasConnected: boolean;
-		reconnect: boolean;
 	}
 
 	export class Client {
 		constructor();
 
-		/**
-		 * Whether the client is connected to the IRC network and successfully registered
-		 */
 		connected: boolean;
-
-		/**
-		 * User information once connected to an IRC network
-		 */
 		user: {
 			nick: string;
-			username: string;
-			gecos: string;
-			host: string;
-			away: string;
-			modes: Set<string>;
 		};
 
-		/**
-		 * Connect to the IRC server
-		 */
 		connect(options: {
 			host: string;
 			port: number;
@@ -92,228 +21,23 @@ declare module "irc-framework" {
 			gecos?: string;
 			password?: string;
 			tls?: boolean;
-			account?:
-				| {
-						account: string;
-						password: string;
-				  }
-				| boolean
-				| Record<string, never>;
+			account?: { account: string; password: string };
 			auto_reconnect?: boolean;
 			auto_reconnect_max_wait?: number;
 			auto_reconnect_max_retries?: number;
 			ping_interval?: number;
 			ping_timeout?: number;
-			enable_chghost?: boolean;
 			enable_echomessage?: boolean;
-			version?: string;
-			encoding?: string;
-			sasl_disconnect_on_fail?: boolean;
-			webirc?: {
-				password: string;
-				username: string;
-				hostname: string;
-				ip: string;
-				options?: {
-					secure?: boolean;
-					"local-port"?: number;
-					"remote-port"?: number;
-				};
-			};
-			client_certificate?: {
-				private_key: string;
-				certificate: string;
-			};
+			outgoing_addr?: string;
 		}): void;
 
-		/**
-		 * Add middleware to handle events
-		 */
-		use(middleware: (client: Client, rawEvents: unknown, parsedEvents: unknown) => void): void;
-
-		/**
-		 * Send a raw line to the IRC server
-		 */
 		raw(line: string): void;
-
-		/**
-		 * Generate a formatted line to be sent to the IRC server
-		 */
-		rawString(command: string | string[], ...args: string[]): string;
-
-		/**
-		 * Quit from the IRC network
-		 */
 		quit(message?: string): void;
-
-		/**
-		 * Ping the IRC server
-		 */
-		ping(message?: string): void;
-
-		/**
-		 * Change the client's nick
-		 */
 		changeNick(nick: string): void;
-
-		/**
-		 * Send a message to a target
-		 */
-		say(target: string, message: string, tags?: Record<string, string>): void;
-
-		/**
-		 * Send a notice to a target
-		 */
-		notice(target: string, message: string, tags?: Record<string, string>): void;
-
-		/**
-		 * Send a tagged message without content to a target
-		 */
-		tagmsg(target: string, tags: Record<string, string>): void;
-
-		/**
-		 * Join a channel
-		 */
-		join(channel: string, key?: string): void;
-
-		/**
-		 * Part/leave a channel
-		 */
-		part(channel: string, message?: string): void;
-
-		/**
-		 * Set the topic of a channel
-		 */
-		setTopic(channel: string, newTopic: string): void;
-
-		/**
-		 * Remove the topic of a channel
-		 */
-		clearTopic(channel: string): void;
-
-		/**
-		 * Send a CTCP request to a target
-		 */
-		ctcpRequest(target: string, type: string, ...params: string[]): void;
-
-		/**
-		 * Send a CTCP response to a target
-		 */
-		ctcpResponse(target: string, type: string, ...params: string[]): void;
-
-		/**
-		 * Send an action message to a target
-		 */
-		action(target: string, message: string): void;
-
-		/**
-		 * Receive information about a user on the network
-		 */
-		whois(nick: string, callback?: (event: WhoisEvent) => void): void;
-
-		/**
-		 * Receive a list of users on the network that matches the target
-		 */
-		who(target: string, callback?: (event: WhoEvent) => void): void;
-
-		/**
-		 * Request that the IRC server sends a list of available channels
-		 */
-		list(...params: string[]): void;
-
-		/**
-		 * Create a channel object
-		 */
-		channel(
-			channelName: string,
-			key?: string,
-		): {
-			say(message: string): void;
-			notice(message: string): void;
-			action(message: string): void;
-			part(partMessage?: string): void;
-			join(key?: string): void;
-		};
-
-		/**
-		 * Compare two strings using the networks casemapping setting
-		 */
-		caseCompare(string1: string, string2: string): boolean;
-
-		/**
-		 * Uppercase the characters in string using the networks casemapping setting
-		 */
-		caseUpper(string: string): string;
-
-		/**
-		 * Lowercase the characters in string using the networks casemapping setting
-		 */
-		caseLower(string: string): string;
-
-		/**
-		 * Call a callback when any incoming message matches a regex
-		 */
-		match(
-			matchRegex: RegExp,
-			callback: (event: Record<string, unknown>) => void,
-			messageType?: string,
-		): void;
-
-		/**
-		 * Call a callback when an incoming notice message matches a regex
-		 */
-		matchNotice(matchRegex: RegExp, callback: (event: Record<string, unknown>) => void): void;
-
-		/**
-		 * Call a callback when an incoming plain message matches a regex
-		 */
-		matchMessage(matchRegex: RegExp, callback: (event: Record<string, unknown>) => void): void;
-
-		/**
-		 * Call a callback when an incoming action message matches a regex
-		 */
-		matchAction(matchRegex: RegExp, callback: (event: Record<string, unknown>) => void): void;
-
-		/**
-		 * Add a target to the list of targets being monitored
-		 */
-		addMonitor(target: string): void;
-
-		/**
-		 * Remove a target from the list of targets being monitored
-		 */
-		removeMonitor(target: string): void;
-
-		/**
-		 * Clear the list of targets being monitored
-		 */
-		clearMonitor(): void;
-
-		/**
-		 * Return the current list of targets being monitored
-		 */
-		monitorlist(callback?: (nicks: string[]) => void): void;
-
-		/**
-		 * Query the current list of targets being monitored
-		 */
-		queryMonitor(): void;
-
-		/**
-		 * Request an extra IRCv3 capability
-		 */
-		requestCap(capability: string): void;
-
-		/**
-		 * Event handler
-		 */
-		on(event: "registered", listener: (event: IrcRegisteredEvent) => void): this;
+		say(target: string, message: string): void;
+		join(channel: string): void;
 		on(event: "message", listener: (event: IrcMessageEvent) => void): this;
 		on(event: "privmsg", listener: (event: IrcMessageEvent) => void): this;
-		on(event: "notice", listener: (event: IrcMessageEvent) => void): this;
-		on(event: "action", listener: (event: IrcMessageEvent) => void): this;
-		on(event: "error", listener: (event: IrcErrorEvent) => void): this;
-		on(event: "close", listener: (event: IrcCloseEvent) => void): this;
 		on(event: string, listener: (...args: unknown[]) => void): this;
 	}
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,6 +1,3 @@
-// F1 API Models
-
-// Driver model
 export interface Driver {
 	racingNumber: number;
 	reference: string;
@@ -13,38 +10,6 @@ export interface Driver {
 	teamColor: string;
 }
 
-// Session Info model
-export interface SessionInfo {
-	archiveStatus: {
-		status: string;
-	};
-	endDate: string;
-	gmtOffset: string;
-	key: number;
-	meeting: {
-		circuit: {
-			key: number;
-			shortName: string;
-		};
-		country: {
-			code: string;
-			key: number;
-			name: string;
-		};
-		key: number;
-		location: string;
-		name: string;
-		number: number;
-		officialName: string;
-	};
-	name: string;
-	number: number;
-	path: string;
-	startDate: string;
-	type: string;
-}
-
-// Driver Standing model
 export interface DriverStanding {
 	position: number;
 	driverName: string;
@@ -53,129 +18,38 @@ export interface DriverStanding {
 	difference?: string;
 }
 
-// Session Results model
 export interface SessionResults {
 	title: string;
 	standings: DriverStanding[];
 }
 
-// Event Tracker model
-export interface EventTracker {
-	race: {
-		meetingOfficialName: string;
-	};
-	seasonContext: {
-		timetables: Array<{
-			description: string;
-			state: string;
-			startTime: string;
-			gmtOffset: string;
+export interface DriverMRData {
+	StandingsTable: {
+		season: string;
+		StandingsLists: Array<{
+			DriverStandings: Array<{
+				position: string;
+				points: string;
+				Driver: {
+					code: string;
+				};
+			}>;
 		}>;
 	};
 }
 
-// Ergast API Models
-
-// Ergast Driver model
-export interface ErgastDriver {
-	driverId: string;
-	permanentNumber: string;
-	code: string;
-	url: string;
-	givenName: string;
-	familyName: string;
-	dateOfBirth: string;
-	nationality: string;
-}
-
-// Constructor model
-export interface Constructor {
-	constructorId: string;
-	url: string;
-	name: string;
-	nationality: string;
-}
-
-// Ergast Driver Standing model
-export interface ErgastDriverStanding {
-	position: string;
-	positionText: string;
-	points: string;
-	wins: string;
-	Driver: ErgastDriver;
-	Constructors: Constructor[];
-}
-
-// Constructor Standing model
-export interface ConstructorStanding {
-	position: string;
-	positionText: string;
-	points: string;
-	wins: string;
-	Constructor: Constructor;
-}
-
-// Standings Lists
-export interface DriverStandingsList {
-	season: string;
-	round: string;
-	DriverStandings: ErgastDriverStanding[];
-}
-
-export interface ConstructorStandingsList {
-	season: string;
-	round: string;
-	ConstructorStandings: ConstructorStanding[];
-}
-
-// Standings Tables
-export interface DriverStandingsTable {
-	season: string;
-	StandingsLists: DriverStandingsList[];
-}
-
-export interface ConstructorStandingsTable {
-	season: string;
-	StandingsLists: ConstructorStandingsList[];
-}
-
-// MRData models
-export interface DriverMRData {
-	xmlns: string;
-	series: string;
-	url: string;
-	limit: string;
-	offset: string;
-	total: string;
-	StandingsTable: DriverStandingsTable;
-}
-
 export interface ConstructorMRData {
-	xmlns: string;
-	series: string;
-	url: string;
-	limit: string;
-	offset: string;
-	total: string;
-	StandingsTable: ConstructorStandingsTable;
+	StandingsTable: {
+		season: string;
+		StandingsLists: Array<{
+			ConstructorStandings: Array<{
+				position: string;
+				points: string;
+				Constructor: {
+					name: string;
+				};
+			}>;
+		}>;
+	};
 }
 
-// Current Standings models
-export interface CurrentDriverStandings {
-	MRData: DriverMRData;
-}
-
-export interface CurrentConstructorStandings {
-	MRData: ConstructorMRData;
-}
-
-// Calendar Events model
-export interface CalendarEvent {
-	name: string;
-	slug: string;
-	sessions: Record<string, string>;
-}
-
-export interface CalendarEvents {
-	races: CalendarEvent[];
-}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -52,4 +52,3 @@ export interface ConstructorMRData {
 		}>;
 	};
 }
-

--- a/src/utils/events.ts
+++ b/src/utils/events.ts
@@ -1,25 +1,14 @@
 import { EventType } from "~/types/event-type";
 
-const typeNames: Record<EventType, string> = {
-	[EventType.LiveryReveal]: "Livery Reveal",
-	[EventType.FreePractice1]: "Free Practice 1",
-	[EventType.FreePractice2]: "Free Practice 2",
-	[EventType.FreePractice3]: "Free Practice 3",
-	[EventType.Qualifying]: "Qualifying",
-	[EventType.Sprint]: "Sprint",
-	[EventType.Race]: "Race",
-	[EventType.SprintQualifying]: "Sprint Qualifying",
-};
-
-const typeEmojis: Record<EventType, string> = {
-	[EventType.LiveryReveal]: "🎨",
-	[EventType.FreePractice1]: "🏎️",
-	[EventType.FreePractice2]: "🏎️",
-	[EventType.FreePractice3]: "🏎️",
-	[EventType.Qualifying]: "⏱️",
-	[EventType.Sprint]: "🏁",
-	[EventType.Race]: "🏎️",
-	[EventType.SprintQualifying]: "⏱️",
+const eventTypeMetadata: Record<EventType, { name: string; emoji: string }> = {
+	[EventType.LiveryReveal]: { name: "Livery Reveal", emoji: "🎨" },
+	[EventType.FreePractice1]: { name: "Free Practice 1", emoji: "🏎️" },
+	[EventType.FreePractice2]: { name: "Free Practice 2", emoji: "🏎️" },
+	[EventType.FreePractice3]: { name: "Free Practice 3", emoji: "🏎️" },
+	[EventType.Qualifying]: { name: "Qualifying", emoji: "⏱️" },
+	[EventType.Sprint]: { name: "Sprint", emoji: "🏁" },
+	[EventType.Race]: { name: "Race", emoji: "🏎️" },
+	[EventType.SprintQualifying]: { name: "Sprint Qualifying", emoji: "⏱️" },
 };
 
 const stringMap: Array<[string, EventType]> = [
@@ -63,20 +52,16 @@ const sessionKeyMap: Record<string, EventType> = {
 };
 
 export function eventTypeToString(eventType: EventType): string {
-	return typeNames[eventType] ?? "Unknown";
+	return eventTypeMetadata[eventType].name;
 }
 
 export function eventTypeToEmoji(eventType: EventType): string {
-	return typeEmojis[eventType] ?? "🏎️";
+	return eventTypeMetadata[eventType].emoji;
 }
 
 export function stringToEventType(str?: string): EventType | undefined {
-	if (!str) return undefined;
-	const lower = str.toLowerCase();
-	for (const [key, value] of stringMap) {
-		if (lower.includes(key)) return value;
-	}
-	return undefined;
+	const lower = str?.toLowerCase();
+	return lower ? stringMap.find(([key]) => lower.includes(key))?.[1] : undefined;
 }
 
 export function sessionKeyToEventType(key: string): EventType | null {

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -67,10 +67,7 @@ const jobHandlers: Record<JobType, () => Promise<unknown>> = {
 		});
 		if (newMessages.length === 0) return;
 
-		await markAutopostMessagesSeen(
-			session.Path,
-			newMessages.map(buildRaceControlMessageKey),
-		);
+		await markAutopostMessagesSeen(session.Path, newMessages.map(buildRaceControlMessageKey));
 
 		for (const message of newMessages) {
 			const formattedMessage = formatAutopostRaceControlMessage(session, message);

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -1,19 +1,19 @@
 import { CronJob } from "cron";
-import {
-	fetchWccStandings,
-	fetchWdcStandings,
-	readCurrentEvent,
-	fetchResults,
-	fetchNextEvent,
-} from "~/fetch";
+import { fetchF1Calendar } from "~/calendar";
 import {
 	getAutopostChannels,
 	getSeenAutopostMessageKeys,
 	isEventDelivered,
 	markAutopostMessagesSeen,
 } from "~/database";
+import {
+	fetchNextEvent,
+	fetchResults,
+	fetchWccStandings,
+	fetchWdcStandings,
+	readCurrentEvent,
+} from "~/fetch";
 import { broadcast, sendMessage } from "~/irc";
-import { fetchF1Calendar } from "~/calendar";
 import {
 	buildRaceControlMessageKey,
 	fetchCurrentSessionRaceControlMessages,
@@ -21,9 +21,6 @@ import {
 	shouldAutopostRaceControlMessage,
 } from "~/live-timing";
 
-/**
- * Enum representing different job types
- */
 export enum JobType {
 	Result = "result",
 	Alert = "alert",
@@ -33,97 +30,33 @@ export enum JobType {
 	Autopost = "autopost",
 }
 
-/**
- * Process a job based on its type
- * @param jobType - The type of job to process
- * @returns A promise that resolves when the job is complete
- */
-export async function processJob(jobType: JobType) {
-	try {
-		switch (jobType) {
-			case JobType.Result:
-				return await resultWorker();
-			case JobType.Alert:
-				return await alertWorker();
-			case JobType.Wdc:
-				return await fetchWdcStandings();
-			case JobType.Wcc:
-				return await fetchWccStandings();
-			case JobType.CalendarRefresh:
-				return await fetchF1Calendar();
-			case JobType.Autopost:
-				return await autopostWorker();
-		}
-	} catch (error) {
-		console.error(`Error processing job ${jobType}:`, error);
-		// Don't throw the error further, just log it
-		// This prevents the error from affecting the IRC connection
-	}
-}
-
-function scheduleCron(expression: string, jobType: JobType, jobLabel: string): void {
-	new CronJob(expression, async () => {
-		try {
-			await processJob(jobType);
-		} catch (error) {
-			console.error(`Error in ${jobLabel} job:`, error);
-		}
-	}).start();
-}
-
-/**
- * Check if a new result is posted on the F1 API
- * If so, fetch the results and broadcast them to channels
- * @returns A promise that resolves when the job is complete
- */
-async function resultWorker(): Promise<void> {
-	console.log(`Checking for new results at ${new Date().toISOString()}`);
-
-	try {
+const jobHandlers: Record<JobType, () => Promise<unknown>> = {
+	[JobType.Result]: async () => {
+		console.log(`Checking for new results at ${new Date().toISOString()}`);
 		const { path, isComplete } = await readCurrentEvent();
-		const delivered = await isEventDelivered(path);
+		if (!isComplete || (await isEventDelivered(path))) return;
 
-		if (isComplete && !delivered) {
-			const standings = await fetchResults(path);
-			// Only broadcast if we successfully stored the result (marks delivered)
-			const deliveredNow = await isEventDelivered(path);
-			if (deliveredNow) {
-				await broadcast(standings);
-			} else {
-				console.log(`Results not stored for ${path}; skipping broadcast to avoid spam`);
-			}
+		const standings = await fetchResults(path);
+		if (await isEventDelivered(path)) {
+			await broadcast(standings);
+			return;
 		}
-	} catch (error) {
-		console.error("Error in result worker:", error);
-		// Don't throw the error further, just log it
-		// This prevents the error from affecting the IRC connection
-	}
-}
 
-/**
- * Check if the next scheduled event is within 5 minutes
- * If so, broadcast a message to channels
- * @returns A promise that resolves when the job is complete
- */
-async function alertWorker(): Promise<void> {
-	try {
+		console.log(`Results not stored for ${path}; skipping broadcast to avoid spam`);
+	},
+	[JobType.Alert]: async () => {
 		const event = await fetchNextEvent();
-
 		if (event) {
 			await broadcast(event);
 		}
-	} catch (error) {
-		console.error("Error in alert worker:", error);
-		// Don't throw the error further, just log it
-		// This prevents the error from affecting the IRC connection
-	}
-}
+	},
+	[JobType.Wcc]: () => fetchWccStandings(),
+	[JobType.Wdc]: () => fetchWdcStandings(),
+	[JobType.CalendarRefresh]: () => fetchF1Calendar(),
+	[JobType.Autopost]: async () => {
+		const channels = await getAutopostChannels();
+		if (channels.length === 0) return;
 
-async function autopostWorker(): Promise<void> {
-	const channels = await getAutopostChannels();
-	if (channels.length === 0) return;
-
-	try {
 		const { session, messages } = await fetchCurrentSessionRaceControlMessages();
 		const relevantMessages = messages.filter(shouldAutopostRaceControlMessage);
 		if (relevantMessages.length === 0) return;
@@ -132,7 +65,6 @@ async function autopostWorker(): Promise<void> {
 		const newMessages = relevantMessages.filter((message) => {
 			return !seenKeys.has(buildRaceControlMessageKey(message));
 		});
-
 		if (newMessages.length === 0) return;
 
 		await markAutopostMessagesSeen(
@@ -146,19 +78,28 @@ async function autopostWorker(): Promise<void> {
 				sendMessage(channel, formattedMessage);
 			}
 		}
+	},
+};
+
+const scheduledJobs: Array<[expression: string, jobType: JobType]> = [
+	["*/5 * * * *", JobType.Result],
+	["*/5 * * * *", JobType.Alert],
+	["0 * * * *", JobType.Wdc],
+	["0 * * * *", JobType.Wcc],
+	["0 0 * * *", JobType.CalendarRefresh],
+	["*/30 * * * * *", JobType.Autopost],
+];
+
+export async function processJob(jobType: JobType): Promise<void> {
+	try {
+		await jobHandlers[jobType]();
 	} catch (error) {
-		console.error("Error in autopost worker:", error);
+		console.error(`Error processing job ${jobType}:`, error);
 	}
 }
 
-/**
- * Schedule jobs to run at specific intervals
- */
 export function scheduleJobs(): void {
-	scheduleCron("*/5 * * * *", JobType.Result, "result");
-	scheduleCron("*/5 * * * *", JobType.Alert, "alert");
-	scheduleCron("0 * * * *", JobType.Wdc, "WDC standings");
-	scheduleCron("0 * * * *", JobType.Wcc, "WCC standings");
-	scheduleCron("0 0 * * *", JobType.CalendarRefresh, "calendar refresh");
-	scheduleCron("*/30 * * * * *", JobType.Autopost, "autopost");
+	for (const [expression, jobType] of scheduledJobs) {
+		new CronJob(expression, () => void processJob(jobType)).start();
+	}
 }

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -35,8 +35,12 @@ const liveTimingMocks = {
 		session: { Path: "2026/race/", Meeting: { Name: "Australian Grand Prix" }, Name: "Race" },
 		messages: [] as Array<{ id: string; shouldAutopost?: boolean }>,
 	})),
-	formatAutopostRaceControlMessage: mock((_session: unknown, message: { id: string }) => `msg:${message.id}`),
-	shouldAutopostRaceControlMessage: mock((message: { shouldAutopost?: boolean }) => !!message.shouldAutopost),
+	formatAutopostRaceControlMessage: mock(
+		(_session: unknown, message: { id: string }) => `msg:${message.id}`,
+	),
+	shouldAutopostRaceControlMessage: mock(
+		(message: { shouldAutopost?: boolean }) => !!message.shouldAutopost,
+	),
 };
 
 const cronJobs: Array<{ expression: string; started: boolean }> = [];
@@ -85,7 +89,9 @@ beforeEach(() => {
 	calendarMocks.fetchF1Calendar.mockReset();
 
 	liveTimingMocks.buildRaceControlMessageKey.mockReset();
-	liveTimingMocks.buildRaceControlMessageKey.mockImplementation((message: { id: string }) => message.id);
+	liveTimingMocks.buildRaceControlMessageKey.mockImplementation(
+		(message: { id: string }) => message.id,
+	);
 	liveTimingMocks.fetchCurrentSessionRaceControlMessages.mockReset();
 	liveTimingMocks.fetchCurrentSessionRaceControlMessages.mockResolvedValue({
 		session: { Path: "2026/race/", Meeting: { Name: "Australian Grand Prix" }, Name: "Race" },
@@ -138,9 +144,7 @@ afterEach(() => {
 describe("processJob", () => {
 	test("broadcasts new results only after delivery is confirmed", async () => {
 		fetchMocks.readCurrentEvent.mockResolvedValue({ path: "2026/race/", isComplete: true });
-		databaseMocks.isEventDelivered
-			.mockResolvedValueOnce(false)
-			.mockResolvedValueOnce(true);
+		databaseMocks.isEventDelivered.mockResolvedValueOnce(false).mockResolvedValueOnce(true);
 		fetchMocks.fetchResults.mockResolvedValue("race results");
 
 		await processJob(JobType.Result);


### PR DESCRIPTION
## Summary
- simplify bot code paths and remove dead helpers across IRC, fetch, database, message, calendar, live-timing, and worker modules
- trim local type surface to fields the app actually reads
- normalize repository formatting drift so `bun run check` is green again

## Why
This started as an autoresearch pass focused on reducing production LOC through simplification, not code golf. The result is flatter control flow, fewer one-off helpers, fewer duplicate types, and less special-case state.

## Metrics
- `prod_loc`: `3994 -> 2468` (`-38.2%`)
- `total_loc`: `6387 -> 4861` (`-23.9%`)

## Validation
- `bun run check`
- `bun test`
